### PR TITLE
Fix link issues in Guardrail docs

### DIFF
--- a/en/docs/create-api-proxy/third-party-apis/guardrails.md
+++ b/en/docs/create-api-proxy/third-party-apis/guardrails.md
@@ -3,12 +3,12 @@
 Guardrails are a set of guidelines and best practices designed to ensure the safe and effective use of AI systems. They help mitigate risks and promote responsible AI usage. Bijira provides 3 types of guardrails to enhance the security and reliability of AI APIs:
 
 - **Basic Guardrails**: These are the foundational security measures that apply to all AI APIs, ensuring a baseline level of protection.
-    - [Regex Guardrail](./guardrails/basic-guardrails/regex-guardrail.md)
-    - [Word Count Guardrail](./guardrails/basic-guardrails/word-count-guardrail.md)
-    - [Sentence Count Guardrail](./guardrails/basic-guardrails/sentence-count-guardrail.md)
-    - [Content Length Guardrail](./guardrails/basic-guardrails/content-length-guardrail.md)
-    - [URL Guardrail](./guardrails/basic-guardrails/url-guardrail.md)
+    - [Regex Guardrail](../guardrails/basic-guardrails/regex-guardrail)
+    - [Word Count Guardrail](../guardrails/basic-guardrails/word-count-guardrail)
+    - [Sentence Count Guardrail](../guardrails/basic-guardrails/sentence-count-guardrail)
+    - [Content Length Guardrail](../guardrails/basic-guardrails/content-length-guardrail)
+    - [URL Guardrail](../guardrails/basic-guardrails/url-guardrail)
 - **Advanced Guardrails**: These are additional security measures that can be applied to specific AI APIs, providing enhanced security and control.
 - **Third Party Guardrail Integrations**: These are integrations with third-party services that offer additional security and compliance features for AI APIs.
-    - [Azure Content Safety Content Moderation](./guardrails/third-party-guardrail-integrations/azure-content-safety-content-moderation.md)
-    - [AWS Bedrock Guardrails](./guardrails/third-party-guardrail-integrations/aws-bedrock-guardrails.md)
+    - [Azure Content Safety Content Moderation](../guardrails/third-party-guardrail-integrations/azure-content-safety-content-moderation)
+    - [AWS Bedrock Guardrails](../guardrails/third-party-guardrail-integrations/aws-bedrock-guardrails)

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -118,7 +118,7 @@ nav:
                 - URL Guardrail: create-api-proxy/third-party-apis/guardrails/basic-guardrails/url-guardrail.md
                 # - Third Party Guardrail Integrations:
                 - Azure Content Safety Content Moderation: create-api-proxy/third-party-apis/guardrails/third-party-guardrail-integrations/azure-content-safety-content-moderation.md
-                - AWS Bedrock Guardrail: create-api-proxy/third-party-apis/third-party-guardrail-integrations/aws-bedrock-guardrail.md
+                - AWS Bedrock Guardrail: create-api-proxy/third-party-apis/guardrails/third-party-guardrail-integrations/aws-bedrock-guardrail.md
               - Semantic Cache: create-api-proxy/third-party-apis//semantic-cache.md
         - Get from Marketplace: create-api-proxy/third-party-apis/get-from-marketplace.md
         - Import API Contract: create-api-proxy/third-party-apis/import-api-contract.md


### PR DESCRIPTION
## Purpose
This PR fixes link issues in Guardrail docs.

Related issue: https://github.com/wso2/api-manager/issues/3951