### PR TITLE
Improve clarity in custom policy documentation by correcting phrasing

### DIFF
--- a/en/docs/api-platform-gateway/writing-a-custom-policy.md
+++ b/en/docs/api-platform-gateway/writing-a-custom-policy.md
@@ -39,13 +39,13 @@ Incoming Request
   Downstream Client
 ```
 
-A policy only participates in the phases it implements. For example policy that only inspects request headers simply does not implement the response interfaces.
+A policy only participates in the phases it implements. For example, a policy that only inspects request headers does not implement the response interfaces.
 
 ## How to Write a Policy
 
 ### Step 1: Create the Policy
 
-Each policy lives in its own Go module. Create a directory inside your gateway as policies:
+Each policy lives in its own Go module. Create a "policies" directory inside your gateway:
 
 ```text
 /policies/my-policy/


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and grammar in custom policy documentation, including enhanced examples and clearer instructions for setting up your policies directory within the gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->