### PR TITLE
Clarify supported MCP transport protocol for hosted API Platform servers

### DIFF
--- a/en/docs/mcp-servers/get-started-with-mcp.md
+++ b/en/docs/mcp-servers/get-started-with-mcp.md
@@ -6,9 +6,21 @@ MCP is a JSON-RPC–based protocol designed to standardize how applications inte
 
 MCP follows a host–client–server architecture and supports two primary transport mechanisms: stdio and streamable HTTP. While stdio is commonly used for local communication between clients and servers on the same machine, streamable HTTP is increasingly preferred for remote connections, especially as MCP adoption grows across networked environments. 
 
+> **Note:**  
+> The Model Context Protocol defines both `stdio` and streamable HTTP transports.  
+> - `stdio` is designed for **local, process-level communication** (for example, between a CLI/IDE and a locally running MCP server).  
+> - Streamable HTTP (SSE) is designed for **remote, network-based communication**.  
+>  
+> **MCP servers deployed on the WSO2 API Platform are hosted and accessed over the network. Therefore, only streamable HTTP (SSE) transport is supported.**  
+> MCP clients connecting to API Platform must be configured to use HTTP/SSE, not `stdio`.
+
 For more information, refer to the official [specification](https://modelcontextprotocol.io/introduction).
 
 ## Remote MCP Servers with API Platform
+
+> **Transport Requirement:**  
+> Since API Platform exposes MCP servers as **remote, network-accessible endpoints**, it **does not support `stdio` transport**.  
+> All MCP interactions with API Platform must use **streamable HTTP (SSE)**.
 
 API Platform now includes support for MCP servers. It provides a complete solution for transforming existing APIs into intelligent, AI-ready tools. With a centralized control plane, API Platform simplifies the entire lifecycle of MCP server management—from creation to discovery—delivering a seamless experience for both API developers and AI agent builders. Additionally, API Platform allows you to customize the developer portal to deliver a tailored, MCP-only experience for your consumers.
 

--- a/en/docs/mcp-servers/get-started-with-mcp.md
+++ b/en/docs/mcp-servers/get-started-with-mcp.md
@@ -12,7 +12,7 @@ MCP follows a host–client–server architecture and supports two primary trans
 > - Streamable HTTP (SSE) is designed for **remote, network-based communication**.  
 >  
 > **MCP servers deployed on the WSO2 API Platform are hosted and accessed over the network. Therefore, only streamable HTTP (SSE) transport is supported.**  
-> MCP clients connecting to API Platform must be configured to use HTTP/SSE, not `stdio`.
+> MCP clients connecting to API Platform must be configured to use streamable HTTP (SSE), not `stdio`.
 
 For more information, refer to the official [specification](https://modelcontextprotocol.io/introduction).
 


### PR DESCRIPTION
## Description

This PR updates the **Get Started with MCP Servers** documentation to clearly distinguish between the transport mechanisms defined by the Model Context Protocol and the transport mechanism supported by the WSO2 API Platform hosted environment.

The existing documentation mentions both `stdio` and streamable HTTP as primary MCP transport mechanisms, but does not explicitly clarify which transport is supported by the platform implementation. This may lead to confusion for developers attempting to configure remote MCP clients.

Since the API Platform exposes MCP servers as **remote, network-accessible endpoints**, the `stdio` transport is not applicable in this context because it is designed only for **local process-level communication**.

This update adds explicit notes to clarify that:

- `stdio` is intended for local communication between a client and a server running on the same machine
- API Platform hosted MCP servers support **only streamable HTTP (SSE)**
- Clients must use **HTTP/SSE transport** when connecting to MCP servers deployed on the platform

## Changes Made

- Added a clarification note under the **Overview** section
- Added a transport requirement note under **Remote MCP Servers with API Platform**
- Explicitly documented that `stdio` is **not supported** for hosted MCP server connections
- Improved developer guidance to prevent transport misconfiguration

## Problem Solved

This resolves ambiguity between:

- **protocol-level supported transports**
- **platform-level implementation support**

and improves onboarding clarity for developers new to MCP integrations.

## Impact

This is a **documentation-only change** with no functional impact on the platform.

It improves:
- developer experience
- configuration accuracy
- architectural clarity