### PR TITLE
Add tracking on page load

### DIFF
--- a/en/theme/material/partials/javascripts/base.html
+++ b/en/theme/material/partials/javascripts/base.html
@@ -39,3 +39,21 @@
 {% for path in config.extra_javascript %}
 <script src="{{ path | url }}"></script>
 {% endfor %}
+
+<script>
+  function trackEvent(eventName, properties) {
+    if (moesif) {
+      moesif.track(eventName, {
+        product: "api",
+        asset_type: "docs",
+        domain: window.location.hostname,
+        page_url: window.location.pathname,
+        ...properties,
+      });
+    }
+  }
+  
+  document.addEventListener("DOMContentLoaded", function () {
+    trackEvent("Page-Viewed", { page_title: document.title });
+  });
+</script>


### PR DESCRIPTION
## Purpose
This PR adds client-side usage tracking via Moesif to the doc site. Moesif was already used there, but added an script to record actions on each page visit of the user.

The event in Moesif looks like below.
<img width="1483" height="678" alt="Screenshot 2026-05-12 at 10 33 38" src="https://github.com/user-attachments/assets/6ec81d73-c084-4a9b-ab1c-85dc8cace5d7" />

Resolves https://github.com/wso2-enterprise/apim-gtm/issues/380


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes