### PR TITLE
Mkdocs hooks: Serve Markdown files in parallel to HTML pages during  build

### DIFF
--- a/en/hooks.py
+++ b/en/hooks.py
@@ -103,21 +103,25 @@ def on_post_page(output, page, config, **kwargs):
     return re.sub(r"<title>.*?</title>", f"<title>{full_title}</title>", output, count=1)
 
 def on_page_markdown(markdown, page, config, **kwargs):
-      """Write Markdown files to a parallel .md file in the build output.
-   
-      For example, it creates the file `https://wso2.com/api-platform/docs/get-started.md` 
-      alongside the HTML page.
-      """
-      import os
+    """Write Markdown files to a parallel .md file in the build output.
 
-      site_dir = config["site_dir"]
-      # page.url is like "cloud/ai-gateway/overview/" — strip trailing slash
-      # to produce "cloud/ai-gateway/overview.md"
-      url_path = page.url.rstrip("/")
-      if not url_path:
-          url_path = "index"
-      md_output_path = os.path.join(site_dir, url_path + ".md")
-      os.makedirs(os.path.dirname(md_output_path), exist_ok=True)
-      with open(md_output_path, "w", encoding="utf-8") as f:
-          f.write(markdown)
-      return markdown
+    For example, it creates the file `SITE_DIR/cloud/ai-gateway/overview.md`
+    alongside the HTML page.
+    """
+    site_dir = config["site_dir"]
+    # page.url is like "cloud/ai-gateway/overview/" so strip trailing slash
+    # to produce "cloud/ai-gateway/overview.md".
+    # When use_directory_urls is false, page.url ends in .html so strip that too.
+    url_path = page.url.rstrip("/")
+    if url_path.endswith(".html"):
+        url_path = url_path[:-5]
+    # If page.url is the homepage, after the rstrip, it becomes ""
+    if not url_path:
+        url_path = "index"
+    md_output_path = os.path.join(site_dir, url_path + ".md")
+    parent_dir = os.path.dirname(md_output_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+    with open(md_output_path, "w", encoding="utf-8") as f:
+        f.write(markdown)
+    return markdown

--- a/en/hooks.py
+++ b/en/hooks.py
@@ -101,3 +101,23 @@ def on_post_page(output, page, config, **kwargs):
     full_title = f"{title} | {suffix}" if suffix else title
 
     return re.sub(r"<title>.*?</title>", f"<title>{full_title}</title>", output, count=1)
+
+def on_page_markdown(markdown, page, config, **kwargs):
+      """Write Markdown files to a parallel .md file in the build output.
+   
+      For example, it creates the file `https://wso2.com/api-platform/docs/get-started.md` 
+      alongside the HTML page.
+      """
+      import os
+
+      site_dir = config["site_dir"]
+      # page.url is like "cloud/ai-gateway/overview/" — strip trailing slash
+      # to produce "cloud/ai-gateway/overview.md"
+      url_path = page.url.rstrip("/")
+      if not url_path:
+          url_path = "index"
+      md_output_path = os.path.join(site_dir, url_path + ".md")
+      os.makedirs(os.path.dirname(md_output_path), exist_ok=True)
+      with open(md_output_path, "w", encoding="utf-8") as f:
+          f.write(markdown)
+      return markdown


### PR DESCRIPTION
Please note the title.

This serves the purpose of our AI-readiness efforts. Please see [this issue](https://github.com/wso2-enterprise/apim-gtm/issues/420) and [the comment there](https://github.com/wso2-enterprise/apim-gtm/issues/420#issuecomment-4510970708) for more information. 