### PR TITLE
Update API gateway deployment documentation to change image tag format from "v1.1.0" to "1.1.0"

### DIFF
--- a/en/docs/api-gateway/deployment/high-availability-production-deployment.md
+++ b/en/docs/api-gateway/deployment/high-availability-production-deployment.md
@@ -109,10 +109,10 @@ Before making any other changes, set the controller and runtime image tags to th
 gateway:
   controller:
     image:
-      tag: "v1.1.0"
+      tag: "1.1.0"
   gatewayRuntime:
     image:
-      tag: "v1.1.0"
+      tag: "1.1.0"
 ```
 
 !!! tip


### PR DESCRIPTION
$SUBJECT
