### PR TITLE
Fix side menu bahavior

### DIFF
--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -84,10 +84,11 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Expanded sections start with checked=true due to the vertical-line design.
-  // Fix: uncheck all non-active top-level section toggles on all screen sizes so only
-  // the section containing the current page stays expanded.
-  const topLevelItems = document.querySelectorAll('.md-nav--primary > .md-nav__list > .md-nav__item--nested');
-  topLevelItems.forEach(function(item) {
+  // Fix: uncheck every non-active section toggle at any nesting depth (e.g.
+  // "Guides > Developer Portal") so only the section chain containing the
+  // current page stays expanded on load.
+  const nestedItems = document.querySelectorAll('.md-nav--primary .md-nav__item--nested');
+  nestedItems.forEach(function(item) {
     if (!item.classList.contains('md-nav__item--active')) {
       const toggle = Array.from(item.children).find(function(el) {
         return el.tagName === 'INPUT' && el.type === 'checkbox' && el.classList.contains('md-nav__toggle');
@@ -98,26 +99,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  // Accordion behavior: when any nested item is expanded, collapse all its siblings
-  // at the same level. Applies at every depth (top-level and sub-menus).
-  document.querySelectorAll('.md-nav--primary .md-nav__toggle').forEach(function(toggle) {
-    toggle.addEventListener('change', function() {
-      if (!this.checked) return;
-      const parentItem = this.closest('.md-nav__item--nested');
-      if (!parentItem) return;
-      const parentList = parentItem.parentElement;
-      if (!parentList) return;
-      parentList.querySelectorAll(':scope > .md-nav__item--nested').forEach(function(siblingItem) {
-        if (siblingItem === parentItem) return;
-        const siblingToggle = Array.from(siblingItem.children).find(function(el) {
-          return el.tagName === 'INPUT' && el.type === 'checkbox' && el.classList.contains('md-nav__toggle');
-        });
-        if (siblingToggle) {
-          siblingToggle.checked = false;
-        }
-      });
-    });
-  });
+  // Menu items expand/collapse independently: expanding one item no longer
+  // collapses its siblings. Each item stays open until the user collapses it.
 });
 
 /*


### PR DESCRIPTION
## Purpose
## Improve side navigation expand/collapse behavior

### Summary
Reworks the side menu so navigation sections expand and collapse independently, giving users full control over what stays open.

### Changes
- **Removed accordion auto-collapse.** Previously, expanding any menu item automatically collapsed its siblings at the same level. Now each section stays open until the user collapses it themselves — opening one section no longer closes others.
- **Fixed sections stuck open on load.** Sections using the `verticle-line` style (e.g. `Guides > Developer Portal`) render with their toggle `checked` by default. The on-load cleanup only unchecked top-level sections, so nested ones like `Developer Portal` stayed permanently expanded. The cleanup now runs at every nesting depth.

### Behavior after this change
- On page load, everything is collapsed **except** the section chain containing the current page (so users can see where they are).
- Clicking a section toggles only that section; other open sections are left untouched.
- A section stays open until the user explicitly collapses it.

### Files
- `en/docs/assets/js/theme.js`


## Checklist
 - [ ] Verified that `llms.txt` (located at `en/docs/llms.txt`) is updated for AI readiness content. 
 - [ ] Ensured meaningful alt text for images and that the information contained in an image also appears in text so the relevant info exists in the body of the document.
 - [ ] Added or updated frontmatter for the respective pages.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
