### PR TITLE
Add Traffic Logging documentation for API Gateway 1.2.0

### DIFF
--- a/en/docs/api-gateway/next/analytics/moesif-analytics.md
+++ b/en/docs/api-gateway/next/analytics/moesif-analytics.md
@@ -48,81 +48,119 @@ This capability allows platform administrators and business stakeholders to gain
 
 Analytics is configured entirely through the gateway `config.toml` file and is enabled at a system level.
 
+!!! note
+    Analytics is a **consumer** of a shared data-capture pipeline called the **collector**. The
+    collector has no `enabled` flag of its own — it activates automatically whenever `analytics.enabled`
+    (or `traffic_logging.enabled`) is `true`. See [Traffic Logging](../observability/traffic-logging.md)
+    for the other consumer of this same pipeline, which writes a stdout JSON line per request instead
+    of publishing to an external SaaS.
+
 ### System Parameters (`config.toml`)
 
 #### Analytics
 
 | Parameter | Type    | Required | Default | Description                            |
 | --------- | ------- | -------- |-------- | -------------------------------------- |
-| `enabled` | boolean | Yes      | false   | Enables or disables analytics globally |
+| `enabled` | boolean | Yes      | false   | Enables or disables analytics globally, and activates the collector. |
+| `enabled_publishers` | array of strings | No | `["moesif"]` | Publisher names to activate. Currently only `moesif` is supported. |
 
 #### Publishers
 
+Each entry in `enabled_publishers` must have a matching configuration table under
+`[analytics.publishers.<name>]`.
+
+##### Moesif (`[analytics.publishers.moesif]`)
+
 | Parameter              | Type    | Required | Description                               |
 | ---------------------- | ------- | -------- | ----------------------------------------- |
-| `type`                 | string  | Yes      | Analytics publisher type (Currently limited only to ```moesif``` )                  |
-| `enabled`              | boolean | Yes      | Enables the publisher                     |
-| `settings`             | object | Yes       | Map of Publisher specific attributes required for configuring the publisher client                     |
+| `application_id`       | string  | Yes      | Moesif application identifier |
+| `moesif_base_url`      | string  | No       | Moesif ingestion endpoint (default `https://api.moesif.net`) |
+| `publish_interval`     | int     | Yes       | Interval (seconds) between publish cycles |
+| `event_queue_size`     | int     | Yes       | Maximum events held in memory             |
+| `batch_size`           | int     | Yes       | Maximum events per batch                  |
+| `timer_wakeup_seconds` | int     | Yes       | Publisher timer resolution                |
 
-#### gRPC Event Server
+#### Data capture (`[collector]`)
 
-This section configures both the Envoy access log streaming settings and the ALS (Access Log Service) server that receives those logs. The ALS server runs within the policy-engine component.
+Analytics captures request/response headers and bodies through the shared `[collector]` section (also
+used by Traffic Logging). Capture is off by default — enable only what Moesif needs:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `request_body` | boolean | `false` | Capture the full request body and attach it to published events. |
+| `response_body` | boolean | `false` | Capture the full response body and attach it to published events. |
+| `request_headers` | boolean | `false` | Capture all request headers and attach them to published events. |
+| `response_headers` | boolean | `false` | Capture all response headers and attach them to published events. |
+| `ignore_path_prefixes` | array of strings | `[]` | Path prefixes (e.g. `/health`, `/metrics`) for which no analytics event is produced at all. |
+
+!!! note
+    Masking/redaction is a per-consumer, presentation-time concern, not a collector guarantee — the
+    collector hands every enabled consumer the same raw captured data. Moesif always receives unmasked
+    headers, regardless of any `masked_headers` configuration used by Traffic Logging.
+
+#### ALS transport (`[collector.server]`)
+
+This section configures both the Envoy access log streaming settings and the ALS (Access Log Service)
+server that receives those logs. It is shared with Traffic Logging — the controller reads it to
+configure Envoy's gRPC access-log sink, and the policy-engine reads it to configure the receiving ALS
+server.
 
 | Parameter               | Type     | Required | Default | Description                      |
 | ----------------------- | -------- | -------- |---- | -------------------------------- |
+| `mode`                  | string   | No       | `"uds"` | Transport mode: `"uds"` (Unix domain socket) or `"tcp"`. |
 | `buffer_flush_interval` | duration | No       | `1000000000`| Maximum time Envoy waits(in nanoseconds) before flushing buffered access log entries.|
 | `buffer_size_bytes`     | int      | No       | `16384` | Maximum size of the in-memory buffer used to batch access log entries before sending them to ALS server.                  |
 | `grpc_request_timeout`  | duration | No       | `20000000000` | Timeout duration Envoy waits(in nanoseconds) for a response from the ALS server before considering the log delivery attempt failed.            |
-| `server_port`           | int     | Yes      | - | gRPC port on which the ALS server listens for incoming access log streams from Envoy.      |
-| `shutdown_timeout`      | int     | No       | `600` | Maximum time allowed for the ALS server to gracefully shut down while completing in-flight log processing(in seconds). |
+| `shutdown_timeout`      | duration | No       | `"600s"` | Maximum time allowed for the ALS server to gracefully shut down while completing in-flight log processing. |
 | `als_plain_text`        | boolean | No       | `true` | Use plaintext gRPC        |
 | `public_key_path`       | string | No       | - | Path to the public key used for securing ALS communication when transport-level encryption or authentication is enabled.        |
 | `private_key_path`      | string | No       | - | Path to the private key used for securing ALS communication when transport-level encryption or authentication is enabled.        |
 | `max_message_size`      | int     | No       | `1000000000` |Maximum size of a single gRPC message that the ALS server is allowed to receive from Envoy.      |
 | `max_header_limit`      | int     | No       | `8192` | Maximum allowed size of request or response headers processed by the ALS server      |
 
-**Note:** The hostname for the ALS connection is automatically derived from the policy-engine configuration. The internal log name identifier is set to `"envoy_access_log"` and is not configurable.
+!!! note
+    The ALS gRPC port is fixed at `18090` and is not configurable — this guarantees the controller and
+    policy-engine sides can never disagree on it. The hostname for the ALS connection is automatically
+    derived from the policy-engine configuration. The internal log name identifier is set to
+    `"envoy_access_log"` and is not configurable.
+
+#### Deprecated keys
+
+The following `[analytics]` keys still work, but are deprecated in favor of the shared `[collector]` /
+`[collector.server]` sections above. They are migrated automatically at load time with a warning, so
+existing configs keep working unchanged:
+
+| Deprecated key | Migrated onto | Notes |
+|---|---|---|
+| `analytics.allow_payloads` | `collector.request_body` + `collector.response_body` | Directional flags (below) win over `allow_payloads`. |
+| `analytics.send_request_body` / `send_response_body` | `collector.request_body` / `response_body` | — |
+| `analytics.grpc_event_server.*` | `collector.server.*` | Whole-section migration, applied only while `[collector.server]` is unset and `analytics.enabled = true`. |
+| `analytics.access_logs_service.*` | `collector.server.*` | Same migration as above; `server_port` is dropped since the ALS port is now a fixed constant. |
 
 
 ## Configuration Examples
 
 #### Integrate Moesif Publisher
 
-For Moesif analytics integration, the following publisher-specific attributes must be configured under the `settings` section. These parameters control authentication, batching behavior, and publish intervals for efficient analytics delivery. The required attributes are as follows.
-
-| Parameter              | Type    | Required | Description                               |
-| ---------------------- | ------- | -------- | ----------------------------------------- |
-| `application_id`       | string  | Yes      | Analytics platform application identifier |
-| `publish_interval`     | int     | Yes       | Interval (seconds) between publish cycles |
-| `event_queue_size`     | int     | Yes       | Maximum events held in memory             |
-| `batch_size`           | int     | Yes       | Maximum events per batch                  |
-| `timer_wakeup_seconds` | int     | Yes       | Publisher timer resolution                |
-
-
 ```toml
+[collector]
+request_headers = true
+response_headers = true
+
+[collector.server]
+mode = "uds"
+
 [analytics]
 enabled = true
+enabled_publishers = ["moesif"]
 
-[[analytics.publishers]]
-type = "moesif"
-enabled = true
-
-[analytics.publishers.settings]
+[analytics.publishers.moesif]
 application_id = "<MOESIF_APPLICATION_ID>"
+moesif_base_url = "https://api.moesif.net"
 publish_interval = 5
 event_queue_size = 10000
 batch_size = 50
 timer_wakeup_seconds = 3
-
-[analytics.grpc_event_server]
-buffer_flush_interval = 1000000000
-buffer_size_bytes = 16384
-grpc_request_timeout = 20000000000
-server_port = 18090
-shutdown_timeout = 600
-als_plain_text = true
-max_message_size = 1000000000
-max_header_limit = 8192
 ```
 
 

--- a/en/docs/api-gateway/next/observability/traffic-logging.md
+++ b/en/docs/api-gateway/next/observability/traffic-logging.md
@@ -21,15 +21,6 @@ gateway — who called what, the status code, latencies, request/response header
 bodies. It is designed to be picked up by any log-scraping pipeline (Fluent Bit, Loki, ELK, CloudWatch,
 and so on); see [Centralized Logging](logging.md) for a reference log stack that can collect it.
 
-Two properties distinguish it from [Moesif Analytics](../analytics/moesif-analytics.md):
-
-* **No external SaaS required.** The log line is written to stdout only — there's no analytics
-  publisher, application ID, or outbound network call involved.
-* **No policy dependency.** The line is produced from Envoy's always-on access-log path, not from a
-  policy in the mediation chain. This means a request an auth policy **denies** (short-circuits) still
-  produces a log line with the denial's status code — exactly the traffic an operator most wants
-  visibility into, and something policy-chain-based logging structurally cannot capture.
-
 !!! note
     Traffic Logging and Moesif Analytics are independent consumers of the same underlying data-capture
     pipeline. You can enable either, both, or neither.
@@ -42,18 +33,6 @@ whenever a consumer that needs it is enabled (`analytics.enabled` or `traffic_lo
 Traffic Logging is one such consumer: it reads whatever the collector captured and serializes it to
 stdout.
 
-```
-client → Envoy  (captures headers/body via a system policy; streams the access log entry)
-                                        │
-                                        ▼
-                              policy-engine: builds the event
-                                        │
-                    ┌───────────────────┴───────────────────┐
-                    ▼                                       ▼
-        Moesif publisher (if analytics.enabled)   Traffic Logging (if traffic_logging.enabled)
-          sends events to Moesif                    writes one JSON line per request to stdout
-```
-
 Because emission happens on Envoy's access-log path, it fires for every request Envoy terminates —
 including requests denied by an auth policy before they reach any downstream logic.
 
@@ -61,8 +40,7 @@ including requests denied by an auth policy before they reach any downstream log
 
 At minimum, enable `[traffic_logging]` and turn on whichever `[collector]` capture flags you want
 reflected in the log line. Each `traffic_logging.*_headers` / `*_body` toggle only **selects among**
-what `[collector]` already captured — enabling it while the matching `[collector]` flag is off is a
-no-op.
+what `[collector]` already captured — enabling it while the matching `[collector]` flag is off has no effect.
 
 ```toml
 [collector]
@@ -154,9 +132,6 @@ exclude_fields = ["requestBody", "responseBody", "requestHeaders.authorization"]
   names); every other path segment matches case-sensitively.
 * A path can reach into a nested object produced by a `properties` expression that resolves to a map,
   for example `properties.claims.internal_debug`.
-* `exclude_fields` only **trims** what `request_headers`/`request_body`/`response_headers`/
-  `response_body` already include — it is not a standalone switch. Setting `exclude_fields` alone,
-  with every flow toggle left at its default `false`, still logs no headers or bodies at all.
 
 ## Ignoring paths
 

--- a/en/docs/api-gateway/next/observability/traffic-logging.md
+++ b/en/docs/api-gateway/next/observability/traffic-logging.md
@@ -1,0 +1,289 @@
+---
+title: "Configure Traffic Logging"
+description: "Emit a structured JSON log line for every API request from the API Platform Gateway, with no external SaaS and no policy dependency."
+canonical_url: https://wso2.com/api-platform/docs/api-gateway/observability/traffic-logging/
+md_url: https://wso2.com/api-platform/docs/api-gateway/observability/traffic-logging.md
+tags:
+  - api-gateway
+  - observability
+  - logging
+author: WSO2 API Platform Documentation Team
+last_updated: 2026-07-10
+content_type: "how-to"
+---
+
+# Traffic Logging
+
+## Overview
+
+Traffic Logging writes a single structured JSON line to **stdout** for every request handled by the
+gateway — who called what, the status code, latencies, request/response headers, and (optionally)
+bodies. It is designed to be picked up by any log-scraping pipeline (Fluent Bit, Loki, ELK, CloudWatch,
+and so on); see [Centralized Logging](logging.md) for a reference log stack that can collect it.
+
+Two properties distinguish it from [Moesif Analytics](../analytics/moesif-analytics.md):
+
+* **No external SaaS required.** The log line is written to stdout only — there's no analytics
+  publisher, application ID, or outbound network call involved.
+* **No policy dependency.** The line is produced from Envoy's always-on access-log path, not from a
+  policy in the mediation chain. This means a request an auth policy **denies** (short-circuits) still
+  produces a log line with the denial's status code — exactly the traffic an operator most wants
+  visibility into, and something policy-chain-based logging structurally cannot capture.
+
+!!! note
+    Traffic Logging and Moesif Analytics are independent consumers of the same underlying data-capture
+    pipeline. You can enable either, both, or neither.
+
+## How it works
+
+Request/response header and body capture is a **shared** concern, handled by a capture pipeline called
+the **collector**. The collector itself has no on/off switch of its own — it activates automatically
+whenever a consumer that needs it is enabled (`analytics.enabled` or `traffic_logging.enabled`).
+Traffic Logging is one such consumer: it reads whatever the collector captured and serializes it to
+stdout.
+
+```
+client → Envoy  (captures headers/body via a system policy; streams the access log entry)
+                                        │
+                                        ▼
+                              policy-engine: builds the event
+                                        │
+                    ┌───────────────────┴───────────────────┐
+                    ▼                                       ▼
+        Moesif publisher (if analytics.enabled)   Traffic Logging (if traffic_logging.enabled)
+          sends events to Moesif                    writes one JSON line per request to stdout
+```
+
+Because emission happens on Envoy's access-log path, it fires for every request Envoy terminates —
+including requests denied by an auth policy before they reach any downstream logic.
+
+## Enabling Traffic Logging
+
+At minimum, enable `[traffic_logging]` and turn on whichever `[collector]` capture flags you want
+reflected in the log line. Each `traffic_logging.*_headers` / `*_body` toggle only **selects among**
+what `[collector]` already captured — enabling it while the matching `[collector]` flag is off is a
+no-op.
+
+```toml
+[collector]
+request_headers = true
+response_headers = true
+
+[traffic_logging]
+enabled = true
+request_headers = true
+response_headers = true
+```
+
+With this configuration, every request to every API produces a JSON line on stdout containing request
+and response headers (redacted per `masked_headers`, see below).
+
+## Configuration reference
+
+### `[collector]`
+
+Shared capture pipeline. Configured once; every enabled consumer (Analytics, Traffic Logging) reads
+from it.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `request_body` | boolean | `false` | Capture the full request body into the collected event. |
+| `response_body` | boolean | `false` | Capture the full response body into the collected event. |
+| `request_headers` | boolean | `false` | Capture all request headers into the collected event. |
+| `response_headers` | boolean | `false` | Capture all response headers into the collected event. |
+| `ignore_path_prefixes` | array of strings | `[]` | Path prefixes for which no analytics event and no traffic-log line is produced at all — as if capture were disabled for that one request. See [Ignoring paths](#ignoring-paths). |
+
+!!! note
+    Bodies can be large. Capture is off by default for both request and response bodies — enable only
+    what you need, and use `traffic_logging.max_payload_size` (below) to cap what's written to the log
+    line.
+
+### `[traffic_logging]`
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Emit a stdout JSON line for every request to every API. |
+| `masked_headers` | array of strings | `["authorization", "x-api-key", "x-jwt-assertion"]` | Header names (case-insensitive) whose values are redacted as `****` in the logged `requestHeaders`/`responseHeaders`. |
+| `max_payload_size` | int | `0` | Maximum bytes of request/response payload written per log line. `0` = no limit. Applied output-side only — the collector still captures the full body. |
+| `request_headers` | boolean | `false` | Include captured request headers in the log line. No-op if `collector.request_headers` is `false`. |
+| `request_body` | boolean | `false` | Include the captured request body. No-op if `collector.request_body` is `false`. |
+| `response_headers` | boolean | `false` | Include captured response headers in the log line. No-op if `collector.response_headers` is `false`. |
+| `response_body` | boolean | `false` | Include the captured response body. No-op if `collector.response_body` is `false`. |
+| `exclude_fields` | array of strings | `[]` | Drop named fields from the emitted line. See [Field exclusion](#field-exclusion). |
+
+### `[collector.server]` (ALS transport tuning)
+
+Advanced settings for the Envoy → policy-engine access-log transport shared by the collector. Defaults
+are sensible for most deployments.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `mode` | string | `"uds"` | Transport mode: `"uds"` (Unix domain socket) or `"tcp"`. |
+| `als_plain_text` | boolean | `true` | Use plaintext gRPC (skip TLS). |
+| `public_key_path` / `private_key_path` | string | `""` | TLS keypair for the ALS connection, when `als_plain_text = false`. |
+| `max_message_size` | int | `1000000000` | Maximum size of a single gRPC message the ALS server accepts from Envoy. |
+| `max_header_limit` | int | `8192` | Maximum size of headers processed by the ALS server. |
+| `shutdown_timeout` | duration | `"600s"` | Maximum time allowed for graceful ALS server shutdown. |
+
+!!! note
+    The ALS transport's TCP port is fixed at `18090` and is not configurable — this guarantees the
+    controller and the policy-engine can never disagree on it. `buffer_flush_interval`,
+    `buffer_size_bytes`, and `grpc_request_timeout` are additional Envoy-sender-only keys under
+    `[collector.server]`; see `config-template.toml` for their defaults.
+
+## Redaction and payload control
+
+* **`masked_headers`** redacts matching header values (case-insensitive) to `****` in the logged
+  `requestHeaders`/`responseHeaders` maps. This is applied output-side by Traffic Logging only — other
+  consumers of the collector (such as Moesif) are unaffected and receive unmasked headers.
+* **`max_payload_size`** truncates the request/response body written to the log line. Set to `0`
+  (default) for no limit.
+* **`exclude_fields`** drops named fields from the emitted line entirely, on top of the toggles above.
+
+### Field exclusion
+
+`exclude_fields` accepts top-level keys (e.g. `"latencies"`, `"requestHeaders"`) or dotted paths of
+arbitrary depth into nested JSON objects, for example:
+
+```toml
+[traffic_logging]
+exclude_fields = ["requestBody", "responseBody", "requestHeaders.authorization"]
+```
+
+* Sub-keys immediately under `requestHeaders`/`responseHeaders` match case-insensitively (HTTP header
+  names); every other path segment matches case-sensitively.
+* A path can reach into a nested object produced by a `properties` expression that resolves to a map,
+  for example `properties.claims.internal_debug`.
+* `exclude_fields` only **trims** what `request_headers`/`request_body`/`response_headers`/
+  `response_body` already include — it is not a standalone switch. Setting `exclude_fields` alone,
+  with every flow toggle left at its default `false`, still logs no headers or bodies at all.
+
+## Ignoring paths
+
+`collector.ignore_path_prefixes` suppresses the analytics event — and therefore the traffic-log
+line — for matching paths, such as health checks or metrics scrapes:
+
+```toml
+[collector]
+ignore_path_prefixes = ["/health", "/metrics"]
+```
+
+This is enforced by Envoy itself via an access-log filter, so the policy-engine never even receives
+the request for a matching path.
+
+## Custom properties
+
+`[traffic_logging.properties]` adds extra key → value pairs under a top-level `properties` object in
+the log line. A value prefixed `$ctx:` is evaluated as a CEL expression against the collected request
+context; any other value is emitted as a literal string.
+
+```toml
+[traffic_logging.properties]
+env = "prod"
+apiName = "$ctx:api.name"
+status = "$ctx:response.status"
+subject = "$ctx:auth.subject != '' ? auth.subject : 'anonymous'"
+tenant = "$ctx:'tenant' in auth.property ? auth.property['tenant'] : ''"
+appId = "$ctx:'applicationId' in metadata ? metadata['applicationId'] : ''"
+```
+
+Available variables:
+
+| Namespace | Variables |
+|---|---|
+| Request | `request.path`, `request.method`, `request.id`, `request.header['<name>']` (masked per `masked_headers`) |
+| Response | `response.status`, `response.header['<name>']` (masked per `masked_headers`) |
+| API | `api.id`, `api.name`, `api.version`, `api.context`, `api.kind`, `project.id` |
+| Target | `target.statusCode`, `target.destination` |
+| Application | `application.id`, `application.name`, `application.owner`, `application.keyType` — populated only when an auth policy that stamps application identity (currently `api-key-auth`) ran |
+| Auth | `auth.subject`, `auth.type`, `auth.issuer`, `auth.credential_id`, `auth.token_id`, `auth.audience` (list), `auth.scopes` (list), `auth.property['<claim>']` (map), `auth.authenticated`, `auth.authorized` |
+| Generic metadata | `metadata['<key>']` — any key any policy (including third-party/Python policies) has written into shared request metadata |
+
+`auth.*` is populated generically for **any** authenticated request, regardless of which auth policy
+(`jwt-auth`, `opaque-token-auth`, `api-key-auth`, and so on) ran. For an unauthenticated or denied
+request, every `auth.*` scalar variable resolves to its zero value rather than erroring, so
+`auth.subject != "" ? auth.subject : "anonymous"` is a safe pattern for a property that should always
+resolve to something.
+
+!!! note
+    Indexing into a map or list variable (`auth.property['<claim>']`, `metadata['<key>']`,
+    `auth.audience[0]`) still raises an error if the key or index is absent, and that property is
+    silently omitted from the line. Guard map/list access with the `in` operator, as shown in the
+    `tenant` and `appId` examples above.
+
+!!! note
+    Unlike headers, `metadata['<key>']` has **no masking configuration**. Shared request metadata is a
+    generic, schema-less bag that any policy can write to, so any value referenced from
+    `properties` is emitted verbatim. Avoid referencing metadata keys that may contain sensitive
+    values.
+
+A `$ctx:` expression that references a variable this surface doesn't expose (for example, a typo)
+fails to compile when the gateway starts, is logged once, and that property is permanently omitted
+from every line — it does not cause requests to fail.
+
+## Example log line
+
+```json
+{
+  "timestamp": "2026-07-10T09:12:33.482Z",
+  "correlationId": "5f6b6e2a-2f38-4b7a-9c2f-6b6a2f384b7a",
+  "status": 200,
+  "api": {
+    "id": "01998f3e-...",
+    "name": "Weather-API",
+    "version": "1.0.0",
+    "context": "/weather",
+    "kind": "REST"
+  },
+  "operation": {
+    "method": "GET",
+    "path": "/current"
+  },
+  "target": {
+    "statusCode": 200,
+    "destination": "https://backend.example.com/current"
+  },
+  "application": {
+    "id": "app-123",
+    "name": "Mobile App",
+    "owner": "jdoe",
+    "keyType": "PRODUCTION"
+  },
+  "client": {
+    "ip": "203.0.113.10",
+    "userAgent": "curl/8.4.0"
+  },
+  "latencies": {
+    "durationUs": 18342,
+    "requestMediationLatencyUs": 412,
+    "responseMediationLatencyUs": 298,
+    "backendLatencyUs": 17102
+  },
+  "requestHeaders": {
+    "authorization": "****",
+    "user-agent": "curl/8.4.0"
+  },
+  "responseHeaders": {
+    "content-type": "application/json"
+  },
+  "properties": {
+    "env": "prod",
+    "apiName": "Weather-API",
+    "subject": "jdoe@example.com"
+  }
+}
+```
+
+Fields whose values are entirely empty (for example `application` on an unauthenticated request) are
+omitted from the line rather than emitted as `{}`.
+
+## Kubernetes / Helm
+
+The Helm chart renders `[collector]` (all capture flags, `ignore_path_prefixes`),
+`[collector.server].mode`, and the `[traffic_logging]` flow-selection booleans and `exclude_fields`
+from `.Values.gateway.config`.
+
+!!! note
+    `[traffic_logging.properties]` is not yet rendered by the Helm chart. If you need CEL-derived
+    custom properties in a Helm-deployed gateway, supply a custom `config.toml` override instead of
+    Helm values.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -366,7 +366,9 @@ nav:
           - Deploying APIs:
             - Bottom-Up Deployment: api-gateway/next/deployment/deploying-apis/bottom-up-api-deployment.md
         - Observability:
-          - Logging: api-gateway/next/observability/logging.md
+          - Logging:
+            - Centralized Logging: api-gateway/next/observability/logging.md
+            - Traffic Logging: api-gateway/next/observability/traffic-logging.md
           - Tracing:
             - Overview: api-gateway/next/observability/tracing/overview.md
             - Enabling and Disabling Tracing: api-gateway/next/observability/tracing/enabling-tracing.md


### PR DESCRIPTION
Related to https://github.com/wso2/api-platform/issues/2222

## Summary
- Documents the new stdout JSON **Traffic Logging** consumer and its shared `[collector]` capture pipeline, added in [wso2/api-platform#2580](https://github.com/wso2/api-platform/pull/2580) for gateway v1.2.0.
- New page: `en/docs/api-gateway/next/observability/traffic-logging.md` — overview, how it works, enabling it, config reference for `[collector]`/`[traffic_logging]`/`[collector.server]`, redaction & field-exclusion, path ignoring, custom CEL properties (`auth.*`, `metadata[...]`), sample output, and Helm notes.
- Nav update (`en/mkdocs.yml`): converts the "Logging" leaf under `Api Gateway (next) > Observability` into a group containing "Centralized Logging" (existing, unmoved) and "Traffic Logging" (new).

