### PR TITLE
Update mkdocs.yaml With New Resiliency Block

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -341,7 +341,8 @@ nav:
         - Setup:
           - Storage & Backends: api-gateway/next/setup/storage-and-backends.md
           - Artifact Templating: api-gateway/next/setup/artifact-templating.md
-          - Upstream Timeouts: api-gateway/next/setup/upstream-timeouts.md
+        - Resiliency:
+          - Timeouts: api-gateway/next/resiliency/timeouts.md
         - Quick Start Guide: api-gateway/next/quick-start-guide.md
         - Policies:
           - Overview: api-gateway/next/policies/overview.md
@@ -571,6 +572,8 @@ nav:
             - Overview: ai-gateway/next/deployment-modes/kubernetes/overview.md
             - Standalone Mode: ai-gateway/next/deployment-modes/kubernetes/kubernetes-standalone.md
             - Kubernetes Operator Mode: ai-gateway/next/deployment-modes/kubernetes/gateway-operator.md
+        - Resiliency:
+            - Timeouts: ai-gateway/next/resiliency/timeouts.md
         - Observability:
             - Logging: ai-gateway/next/observability/logging.md
             - Tracing: ai-gateway/next/observability/tracing.md


### PR DESCRIPTION
## Purpose
> Adding the missing mkdocs.yaml updated related to the new resiliency block addition with timeout configs

## Checklist
 - [x] Verified that `llms.txt` (located at `en/docs/llms.txt`) is updated for AI readiness content. 
 - [x] Ensured meaningful alt text for images and that the information contained in an image also appears in text so the relevant info exists in the body of the document.
 - [x] Added or updated frontmatter for the respective pages.

## Related PRs
> - https://github.com/wso2/docs-api-platform/pull/311


