### PR TITLE
Minor doc fix

### DIFF
--- a/en/docs/next/ai-workspace/bottom-up-ai-artifact-deployment-guide.md
+++ b/en/docs/next/ai-workspace/bottom-up-ai-artifact-deployment-guide.md
@@ -338,7 +338,7 @@ The sync behaves exactly the same for these gateways: artifacts loaded from file
   ```yaml
   metadata:
     annotations:
-      "gateway.api-platform.wso2.com/project-id": "Project 1"
+      "gateway.api-platform.wso2.com/project-id": "default"
   ```
 - **A referenced artifact isn't there yet.** An LLM Provider needs its template, and an LLM Proxy needs its provider. Create them in order (template → provider → proxy); the dependent artifact catches up on its own once the one it references has synced.
 


### PR DESCRIPTION
This pull request makes a minor update to the AI artifact deployment guide documentation. The change updates the `project-id` annotation in the YAML example to use `"default"` instead of `"Project 1"` for consistency and clarity.