### PR TITLE
Remove default credentials from gateway and use file config interpolation for encryption key

### DIFF
--- a/en/docs/ai-gateway/next/deployment-modes/kubernetes/gateway-operator.md
+++ b/en/docs/ai-gateway/next/deployment-modes/kubernetes/gateway-operator.md
@@ -410,9 +410,18 @@ curl -X GET "https://raw.githubusercontent.com/wso2/api-platform/refs/heads/main
 
 ### 2. Add Certificate to Gateway
 
+The management API uses basic auth with the credentials from your Helm values
+(`controller.auth.basic.users`; the chart default is `admin` / `admin`). Export them, changing them if
+you overrode the chart defaults:
+
+```sh
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=admin
+```
+
 ```sh
 cert_path="/tmp/test-backend.crt"
-curl -X POST http://localhost:9090/api/management/v0.9/certificates -u "admin:admin" \
+curl -X POST http://localhost:9090/api/management/v0.9/certificates -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/json" \
   -d "{\"certificate\":$(jq -Rs . < $cert_path),\"filename\":\"my-cert.pem\", \"name\":\"test\"}"
 ```

--- a/en/docs/ai-gateway/next/deployment-modes/kubernetes/kubernetes-standalone.md
+++ b/en/docs/ai-gateway/next/deployment-modes/kubernetes/kubernetes-standalone.md
@@ -246,9 +246,18 @@ curl http://localhost:9094/api/admin/v0.9/health
 
 ### Deploy an API configuration
 
+The management API uses basic auth with the credentials from your Helm values
+(`controller.auth.basic.users`; the chart default is `admin` / `admin`). Export them, changing them if
+you overrode the chart defaults:
+
+```bash
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=admin
+```
+
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
-  -u admin:admin \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/aws-bedrock-guardrail.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/aws-bedrock-guardrail.md
@@ -127,7 +127,7 @@ Deploy an LLM provider with AWS Bedrock Guardrail validation:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/azure-content-safety.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/azure-content-safety.md
@@ -118,7 +118,7 @@ Deploy an LLM provider with Azure Content Safety validation:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/content-length.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/content-length.md
@@ -70,7 +70,7 @@ Deploy an LLM provider that limits request payloads to between 100 bytes and 1MB
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/json-schema.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/json-schema.md
@@ -79,7 +79,7 @@ Deploy an LLM provider that validates that request contains a user object with r
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/pii-masking-regex.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/pii-masking-regex.md
@@ -80,7 +80,7 @@ Deploy an LLM provider that masks email addresses and phone numbers in requests 
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/regex.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/regex.md
@@ -79,7 +79,7 @@ Deploy an LLM provider that protects against sensitive data leaks by blocking an
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/semantic-prompt-guard.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/semantic-prompt-guard.md
@@ -129,7 +129,7 @@ Deploy an LLM provider that blocks prompts similar to prohibited phrases:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider
@@ -209,7 +209,7 @@ Deploy an LLM provider that only allows prompts similar to approved phrases:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/sentence-count.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/sentence-count.md
@@ -79,7 +79,7 @@ Deploy an LLM provider that ensures requests contain between 1 and 10 sentences:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/url.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/url.md
@@ -87,7 +87,7 @@ Deploy an LLM provider that validates URLs in request content using HTTP HEAD re
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/guardrails/word-count.md
+++ b/en/docs/ai-gateway/next/llm-proxy/guardrails/word-count.md
@@ -70,7 +70,7 @@ Deploy an LLM provider that validates request messages contain between 10 and 50
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/llm-templates.md
+++ b/en/docs/ai-gateway/next/llm-proxy/llm-templates.md
@@ -298,7 +298,7 @@ To create an LLM provider using any of the out-of-the-box templates:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider
@@ -347,7 +347,7 @@ To list all available LLM provider templates:
 
 ```bash
 curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates \
-  -H "Authorization: Basic YWRtaW46YWRtaW4="
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD"
 ```
 
 ### Retrieving a Specific Template
@@ -356,7 +356,7 @@ To retrieve details of a specific template:
 
 ```bash
 curl -X GET http://localhost:9090/api/management/v0.9/llm-provider-templates/openai \
-  -H "Authorization: Basic YWRtaW46YWRtaW4="
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD"
 ```
 
 ### Creating Custom Templates
@@ -366,7 +366,7 @@ Platform administrators can create custom templates for LLM providers not covere
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-provider-templates \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProviderTemplate
@@ -387,7 +387,7 @@ To update an existing custom template:
 ```bash
 curl -X PUT http://localhost:9090/api/management/v0.9/llm-provider-templates/custom-provider \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProviderTemplate
@@ -408,7 +408,7 @@ To delete a custom template:
 
 ```bash
 curl -X DELETE http://localhost:9090/api/management/v0.9/llm-provider-templates/custom-provider \
-  -H "Authorization: Basic YWRtaW46YWRtaW4="
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD"
 ```
 
 **Note**: Out-of-the-box templates cannot be deleted or modified. Only custom templates created by platform administrators can be updated or deleted.

--- a/en/docs/ai-gateway/next/llm-proxy/load-balancing/model-round-robin.md
+++ b/en/docs/ai-gateway/next/llm-proxy/load-balancing/model-round-robin.md
@@ -69,7 +69,7 @@ Deploy an LLM provider with round-robin load balancing across multiple models:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/load-balancing/model-weighted-round-robin.md
+++ b/en/docs/ai-gateway/next/llm-proxy/load-balancing/model-weighted-round-robin.md
@@ -84,7 +84,7 @@ Deploy an LLM provider with weighted round-robin load balancing:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/prompt-management/prompt-decorator.md
+++ b/en/docs/ai-gateway/next/llm-proxy/prompt-management/prompt-decorator.md
@@ -98,7 +98,7 @@ Add a summarization instruction to user prompts:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider
@@ -171,7 +171,7 @@ Add a system message to define AI behavior:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/prompt-management/prompt-template.md
+++ b/en/docs/ai-gateway/next/llm-proxy/prompt-management/prompt-template.md
@@ -95,7 +95,7 @@ Deploy an LLM provider with a translation prompt template:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider
@@ -168,7 +168,7 @@ Create a template for summarizing content with configurable length:
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
@@ -56,9 +56,15 @@ unzip wso2apip-ai-gateway-1.2.0-beta.zip
 
 cd wso2apip-ai-gateway-1.2.0-beta/
 
-# Run the one-time setup. This provisions the AES-256 at-rest encryption key,
-# the router HTTPS listener certificate, and api-platform.env
+# Run the one-time setup. This provisions the AES-256 at-rest encryption key, the router HTTPS
+# listener certificate, api-platform.env, and the gateway-controller admin credentials. It prints
+# the admin password once — copy it.
 ./scripts/setup.sh
+
+# Export the admin credentials so the management-API calls below can authenticate.
+# The username defaults to "admin"; use the password setup.sh just printed.
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD='<the password scripts/setup.sh printed>'
 
 # Start the complete stack
 docker compose up -d
@@ -74,7 +80,7 @@ The API Platform Gateway currently includes first-class support for the OpenAI L
 ```bash
 curl -X POST http://localhost:9090/api/management/v1/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProvider
@@ -126,7 +132,7 @@ The API Platform Gateway provides first-class support for configuring and deploy
 ```bash
 curl -X POST http://localhost:9090/api/management/v1/llm-proxies \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1
 kind: LlmProxy

--- a/en/docs/ai-gateway/next/llm-proxy/semantic-caching.md
+++ b/en/docs/ai-gateway/next/llm-proxy/semantic-caching.md
@@ -132,7 +132,7 @@ Deploy an LLM provider with semantic caching using OpenAI embeddings and Redis v
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/llm-providers \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1
 kind: LlmProvider

--- a/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
@@ -55,9 +55,15 @@ unzip wso2apip-ai-gateway-1.2.0-beta.zip
 
 cd wso2apip-ai-gateway-1.2.0-beta/
 
-# Run the one-time setup. This provisions the AES-256 at-rest encryption key,
-# the router HTTPS listener certificate, and api-platform.env
+# Run the one-time setup. This provisions the AES-256 at-rest encryption key, the router HTTPS
+# listener certificate, api-platform.env, and the gateway-controller admin credentials. It prints
+# the admin password once — copy it.
 ./scripts/setup.sh
+
+# Export the admin credentials so the management-API calls below can authenticate.
+# The username defaults to "admin"; use the password setup.sh just printed.
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD='<the password scripts/setup.sh printed>'
 
 # Start the complete stack
 docker compose -p ai-gateway up -d
@@ -79,7 +85,7 @@ Run the following command to deploy the MCP proxy.
 ```bash
 curl -X POST http://localhost:9090/api/management/v1/mcp-proxies \
   -H "Content-Type: application/yaml" \
-  -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1
 kind: Mcp

--- a/en/docs/ai-gateway/next/setup/configuration.md
+++ b/en/docs/ai-gateway/next/setup/configuration.md
@@ -100,9 +100,10 @@ The gateway has **no development or demo mode** and **never auto-generates keys 
 
 - **AES-256 at-rest encryption key** — used to encrypt sensitive data at rest. Required; the controller will not start without it.
 - **Router HTTPS listener certificate** — the TLS certificate/key for the router's HTTPS listener.
+- **Admin credentials** — the gateway-controller management API basic-auth credential. There is no hardcoded `admin:admin`; the controller fails closed if basic auth is enabled with no credential.
 - **`api-platform.env`** — runtime settings read directly by the gateway-runtime entrypoint (for example, `GATEWAY_CONTROLLER_HOST`, `LOG_LEVEL`).
 
-The setup script provisions all three.
+The setup script provisions all four.
 
 ## One-time setup with `setup.sh`
 
@@ -119,14 +120,25 @@ docker compose up -d
 |----------|----------|---------|
 | Router listener certificate | `listener-certs/default-listener.{crt,key}` | Self-signed cert for the router HTTPS listener (SANs include `localhost`, `*.localhost`, `host.docker.internal`, `127.0.0.1`). |
 | AES-256 encryption key | `aesgcm-keys/default-aesgcm256-v1.bin` | 32-byte at-rest encryption key, bind-mounted into the controller. |
+| Admin credentials | `api-platform.env` | Gateway-controller REST/management API basic-auth credential (`APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME` + bcrypt `..._PASSWORD_HASH`). |
 | `api-platform.env` | `api-platform.env` | Runtime defaults loaded into the containers via `env_file`. |
+
+!!! note "Admin credentials"
+    The gateway-controller management API is protected by basic auth. You provide the plaintext
+    `ADMIN_USERNAME` (defaults to `admin`) and `ADMIN_PASSWORD` (used if set, otherwise prompted,
+    otherwise randomly generated) to `setup.sh`; it writes
+    `APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME` and the **bcrypt** `..._PASSWORD_HASH` into
+    `api-platform.env` (the tokens `config.toml` reads) and prints the plaintext password **once** — copy
+    it. For non-interactive use: `ADMIN_USERNAME=admin ADMIN_PASSWORD='…' ./scripts/setup.sh`. If those
+    tokens are unset when the controller starts with the shipped `config.toml`, it **refuses to start**
+    rather than running on an empty credential.
 
 The script is **idempotent** — existing files are kept, not overwritten. Flags:
 
 | Flag | Effect |
 |------|--------|
-| `--force` | Regenerate the certificate and encryption key (rotating them) and rewrite `api-platform.env`. |
-| `--certs-only` | Generate only the listener TLS certificate; skip the encryption key and `api-platform.env`. |
+| `--force` | Regenerate the certificate and encryption key (rotating them), rewrite `api-platform.env`, and re-provision the admin credentials (rotating the password). |
+| `--certs-only` | Generate only the listener TLS certificate; skip the encryption key, admin credentials, and `api-platform.env`. |
 
 !!! warning "Rotating the encryption key"
     Running `setup.sh --force` regenerates the AES-256 encryption key. Data encrypted with the previous key becomes unreadable. Only rotate the key deliberately.

--- a/en/docs/api-gateway/next/deployment/deploying-apis/bottom-up-api-deployment.md
+++ b/en/docs/api-gateway/next/deployment/deploying-apis/bottom-up-api-deployment.md
@@ -89,6 +89,7 @@ In bottom-up deployment, **REST APIs deployed directly to the gateway are automa
 
 **File:** `config.toml`
 
+{% raw %}
 ```toml
 [controller.server]
 gateway_id = "gateway-1"
@@ -114,10 +115,12 @@ gateway_name = "onprem-gw"
 enabled = true
 
 [[controller.auth.basic.users]]
-username = "admin"
-password = "admin"
-roles = ["admin"]
+username        = '{{ env "APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME" "" }}'
+password        = '{{ env "APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_PASSWORD_HASH" "" }}'
+password_hashed = true
+roles           = ["admin"]
 ```
+{% endraw %}
 
 ---
 
@@ -334,9 +337,11 @@ spec:
 **Step 2: Deploy to Gateway**
 
 !!! note
-    The examples below use a `BASE64_CREDENTIALS` environment variable for the Basic auth header. Set it before running any `curl` command:
+    The examples below use a `BASE64_CREDENTIALS` environment variable for the Basic auth header. Set it from the admin credentials `scripts/setup.sh` provisioned — the username defaults to `admin`; use the password it printed:
     ```bash
-    export BASE64_CREDENTIALS=$(echo -n "admin:admin" | base64)
+    export ADMIN_USERNAME=admin
+    export ADMIN_PASSWORD='<the password scripts/setup.sh printed>'
+    export BASE64_CREDENTIALS=$(echo -n "$ADMIN_USERNAME:$ADMIN_PASSWORD" | base64)
     ```
 
 ```bash

--- a/en/docs/api-gateway/next/deployment/deployment-modes/kubernetes/gateway-operator.md
+++ b/en/docs/api-gateway/next/deployment/deployment-modes/kubernetes/gateway-operator.md
@@ -743,9 +743,18 @@ curl -X GET "https://raw.githubusercontent.com/wso2/api-platform/refs/heads/main
 
 ### 2. Add Certificate to Gateway
 
+The management API uses basic auth with the credentials from your Helm values
+(`controller.auth.basic.users`; the chart default is `admin` / `admin`). Export them, changing them if
+you overrode the chart defaults:
+
+```sh
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=admin
+```
+
 ```sh
 cert_path="/tmp/test-backend.crt"
-curl -X POST http://localhost:9090/api/management/v0.9/certificates -u "admin:admin" \
+curl -X POST http://localhost:9090/api/management/v0.9/certificates -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/json" \
   -d "{\"certificate\":$(jq -Rs . < $cert_path),\"filename\":\"my-cert.pem\", \"name\":\"test\"}"
 ```

--- a/en/docs/api-gateway/next/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
+++ b/en/docs/api-gateway/next/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
@@ -247,9 +247,18 @@ curl http://localhost:9094/api/admin/v0.9/health
 
 ### Deploy an API configuration
 
+The management API uses basic auth with the credentials from your Helm values
+(`controller.auth.basic.users`; the chart default is `admin` / `admin`). Export them, changing them if
+you overrode the chart defaults:
+
+```bash
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=admin
+```
+
 ```bash
 curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
-  -u admin:admin \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1

--- a/en/docs/api-gateway/next/deployment/production-deployment/control-plane-connection.md
+++ b/en/docs/api-gateway/next/deployment/production-deployment/control-plane-connection.md
@@ -82,6 +82,8 @@ The WSO2 API Platform gateway supports two fundamentally different deployment ap
     Register a DCR client against your APIM instance to obtain the client ID and secret:
 
     ```bash
+    # Use your WSO2 APIM instance's admin credentials here (the APIM control plane's own
+    # superadmin — not the gateway-controller credential provisioned by setup.sh).
     curl -k -X POST https://<APIM_HOST>/client-registration/v0.17/register \
       -H "Content-Type: application/json" \
       -u admin:admin \

--- a/en/docs/api-gateway/next/policies/custom-policies/building-gateway-with-custom-policies.md
+++ b/en/docs/api-gateway/next/policies/custom-policies/building-gateway-with-custom-policies.md
@@ -240,9 +240,17 @@ docker compose up -d
 
 ## Deploy the API
 
+The management API uses basic auth. Export the admin credentials `scripts/setup.sh` provisioned (the
+username defaults to `admin`; use the password it printed):
+
+```sh
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD='<the password scripts/setup.sh printed>'
+```
+
 ```sh
 curl -X POST http://localhost:9090/api/management/v0.9/rest-apis \
-  -u admin:admin \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1alpha1

--- a/en/docs/api-gateway/next/quick-start-guide.md
+++ b/en/docs/api-gateway/next/quick-start-guide.md
@@ -44,8 +44,14 @@ unzip wso2apip-api-gateway-1.2.0-beta.zip
 cd wso2apip-api-gateway-1.2.0-beta/
 
 # Run the one-time setup. This provisions the AES-256 at-rest encryption key,
-# the router HTTPS listener certificate, and api-platform.env
+# the router HTTPS listener certificate, api-platform.env, and the gateway-controller
+# admin credentials. It prints the admin password once — copy it.
 ./scripts/setup.sh
+
+# Export the admin credentials so the management-API calls below can authenticate.
+# The username defaults to "admin"; use the password setup.sh just printed.
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD='<the password scripts/setup.sh printed>'
 
 # Start the complete stack
 docker compose up -d
@@ -55,7 +61,7 @@ curl http://localhost:9094/api/admin/v1/health
 
 # Deploy an API configuration
 curl -X POST http://localhost:9090/api/management/v1/rest-apis \
-  -u admin:admin \
+  -u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
   -H "Content-Type: application/yaml" \
   --data-binary @- <<'EOF'
 apiVersion: gateway.api-platform.wso2.com/v1

--- a/en/docs/api-gateway/next/setup/configuration.md
+++ b/en/docs/api-gateway/next/setup/configuration.md
@@ -100,9 +100,11 @@ The gateway has **no development or demo mode** and **never auto-generates keys 
 
 - **AES-256 at-rest encryption key** — used to encrypt sensitive data at rest. Required; the controller will not start without it.
 - **Router HTTPS listener certificate** — the TLS certificate/key for the router's HTTPS listener.
+- **Admin credentials** — the gateway-controller management API basic-auth credential.
+The controller fails closed if basic auth is enabled with no credential.
 - **`api-platform.env`** — runtime settings read directly by the gateway-runtime entrypoint (for example, `GATEWAY_CONTROLLER_HOST`, `LOG_LEVEL`).
 
-The setup script provisions all three.
+The setup script provisions all four.
 
 ## One-time setup with `setup.sh`
 
@@ -119,14 +121,25 @@ docker compose up -d
 |----------|----------|---------|
 | Router listener certificate | `listener-certs/default-listener.{crt,key}` | Self-signed cert for the router HTTPS listener (SANs include `localhost`, `*.localhost`, `host.docker.internal`, `127.0.0.1`). |
 | AES-256 encryption key | `aesgcm-keys/default-aesgcm256-v1.bin` | 32-byte at-rest encryption key, bind-mounted into the controller. |
+| Admin credentials | `api-platform.env` | Gateway-controller REST/management API basic-auth credential (`APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME` + bcrypt `..._PASSWORD_HASH`) |
 | `api-platform.env` | `api-platform.env` | Runtime defaults loaded into the containers via `env_file`. |
+
+!!! note "Admin credentials"
+    The gateway-controller management API is protected by basic auth. You provide the plaintext
+    `ADMIN_USERNAME` (defaults to `admin`) and `ADMIN_PASSWORD` (used if set, otherwise prompted,
+    otherwise randomly generated) to `setup.sh`; it writes
+    `APIP_GW_CONTROLLER_AUTH_BASIC_ADMIN_USERNAME` and the **bcrypt** `..._PASSWORD_HASH` into
+    `api-platform.env` (the tokens `config.toml` reads) and prints the plaintext password **once** — copy
+    it. For non-interactive use: `ADMIN_USERNAME=admin ADMIN_PASSWORD='…' ./scripts/setup.sh`. If those
+    tokens are unset when the controller starts with the shipped `config.toml`, it **refuses to start**
+    rather than running on an empty credential.
 
 The script is **idempotent** — existing files are kept, not overwritten. Flags:
 
 | Flag | Effect |
 |------|--------|
-| `--force` | Regenerate the certificate and encryption key (rotating them) and rewrite `api-platform.env`. |
-| `--certs-only` | Generate only the listener TLS certificate; skip the encryption key and `api-platform.env`. |
+| `--force` | Regenerate the certificate and encryption key (rotating them), rewrite `api-platform.env`, and re-provision the admin credentials (rotating the password). |
+| `--certs-only` | Generate only the listener TLS certificate; skip the encryption key, admin credentials, and `api-platform.env`. |
 
 !!! warning "Rotating the encryption key"
     Running `setup.sh --force` regenerates the AES-256 encryption key. Data encrypted with the previous key becomes unreadable. Only rotate the key deliberately.

--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -99,7 +99,7 @@ The Get Started section provides setup instructions for multiple deployment opti
 
     **Step 2: Set up the Gateway**
 
-    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
+    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, the gateway-controller admin credentials, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key, certificate, or credential is missing). The admin password is printed once — copy it:
 
     ```bash
     cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh
@@ -155,7 +155,7 @@ The Get Started section provides setup instructions for multiple deployment opti
 
     **Step 2: Set up the Gateway**
 
-    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
+    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, the gateway-controller admin credentials, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key, certificate, or credential is missing). The admin password is printed once — copy it:
 
     ```bash
     cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh
@@ -199,7 +199,7 @@ The Get Started section provides setup instructions for multiple deployment opti
 
     **Step 2: Set up the Gateway**
 
-    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
+    Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, the gateway-controller admin credentials, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key, certificate, or credential is missing). The admin password is printed once — copy it:
 
     ```bash
     cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh

--- a/en/docs/next/ai-workspace/configuration.md
+++ b/en/docs/next/ai-workspace/configuration.md
@@ -1,0 +1,156 @@
+---
+title: "AI Workspace Configuration and Environment Interpolation"
+description: "How AI Workspace and the Platform API load their config.toml files, inject environment values through interpolation tokens, and bootstrap the keys and certificates the stack requires with the setup script."
+canonical_url: https://wso2.com/api-platform/docs/ai-workspace/configuration/
+md_url: https://wso2.com/api-platform/docs/ai-workspace/configuration.md
+tags:
+  - ai-workspace
+  - configuration
+  - interpolation
+author: WSO2 API Platform Documentation Team
+last_updated: 2026-07-24
+content_type: "reference"
+---
+
+# AI Workspace Configuration and Environment Interpolation
+
+The AI Workspace stack - the AI Workspace BFF and the Platform API it proxies to - reads its configuration from TOML files (`config.toml`) layered over built-in defaults. This page explains how configuration is delivered, how environment values are injected through interpolation tokens, and how the one-time setup script provisions the keys and certificates the stack requires.
+
+## How configuration is loaded
+
+Each service reads a TOML file mounted into its container, layered over that service's built-in defaults:
+
+- **AI Workspace (BFF)** - `/etc/ai-workspace/config.toml`; every key lives under the `[ai_workspace]` table.
+- **Platform API** - `/etc/platform-api/config.toml`; every key lives under the `[platform_api]` table.
+
+The per-service namespacing (`[ai_workspace]`, `[platform_api]`, `[developer_portal]`) lets one `config.toml` hold multiple services' sections side by side without their keys colliding - each service reads only its own table.
+
+!!! important "Environment variables do not override config keys directly"
+    There is **no prefix that auto-maps environment variables onto config keys.** An environment value reaches a setting **only** through an explicit interpolation token written into the config file, resolved when the file is loaded. A key written as a plain literal - or absent from the file - ignores the matching variable entirely.
+
+## Interpolation tokens
+
+Two functions are available inside `config.toml`:
+
+{% raw %}
+
+| Token | Behavior |
+|-------|----------|
+| `{{ env "NAME" "default" }}` | Substitutes the value of environment variable `NAME`. If the variable is unset **or set-but-empty**, the `default` is used. If no default is given, an unset variable fails startup. |
+| `{{ file "PATH" }}` | Reads a secret value from a mounted file at `PATH` - for injecting secrets from a mounted volume rather than an environment variable. A trailing newline is trimmed. |
+
+An example from the shipped AI Workspace `config.toml`:
+
+```toml
+[ai_workspace.control_plane]
+url = '{{ env "APIP_AIW_CONTROL_PLANE_URL" "https://platform-api:9243" }}'
+
+[ai_workspace.auth]
+mode = '{{ env "APIP_AIW_AUTH_MODE" "basic" }}'
+```
+
+{% endraw %}
+
+Every token in the shipped config carries a default, so an unset variable keeps the built-in value.
+
+!!! note "The token argument is a naming convention, not a prefix override"
+    By convention each token names the key's dotted path (the table segment and key, uppercased, dots as underscores), prefixed per service: **`APIP_AIW_`** for AI Workspace (so `[ai_workspace.control_plane] url` → `APIP_AIW_CONTROL_PLANE_URL`), **`APIP_CP_`** for the Platform API, and **`APIP_DP_`** for the Developer Portal. This is purely the literal string passed to the interpolation function - not a prefix the loader interprets - so renaming the variable also requires editing the matching token in the config file.
+
+### Common tokens
+
+The shipped config files already carry interpolation tokens for the settings the sample deployments inject. The most common are:
+
+| Environment variable (token argument) | Config key | Description |
+|----------------------------------------|------------|-------------|
+| `APIP_AIW_CONTROL_PLANE_URL` | `ai_workspace.control_plane.url` | Absolute URL the BFF uses to reach the Platform API (e.g. `https://platform-api:9243`) |
+| `APIP_AIW_AUTH_MODE` | `ai_workspace.auth.mode` | `basic` (file-based local auth) or `oidc` (external IDP) |
+| `APIP_AIW_AUTH_OIDC_CLIENT_ID` / `..._CLIENT_SECRET` | `ai_workspace.auth.oidc.*` | OIDC confidential-client credentials (only in `oidc` mode) |
+| `APIP_AIW_LOGGING_LEVEL` | `ai_workspace.logging.level` | `debug`, `info`, `warn`, `error` |
+| `APIP_CP_ADMIN_USERNAME` | `platform_api.auth.file.users[].username` | Basic-auth admin username |
+| `APIP_CP_ADMIN_PASSWORD_HASH` | `platform_api.auth.file.users[].password_hash` | **bcrypt** hash of the admin password |
+| `APIP_CP_LOGGING_LEVEL` | `platform_api.logging.level` | `debug`, `info`, `warn`, `error` |
+
+For the complete list of tokens and every configurable option, refer to the config templates: [AI Workspace](https://github.com/wso2/api-platform/blob/main/portals/ai-workspace/configs/config-template.toml) and [Platform API](https://github.com/wso2/api-platform/blob/main/platform-api/config/config-template.toml).
+
+## Secrets
+
+Never write a secret as a literal in `config.toml`, and never hardcode one in `docker-compose.yaml`. Reference each with an interpolation token - from an environment variable or, preferably, from a mounted file:
+
+{% raw %}
+
+```toml
+# Platform API at-rest encryption key - the shipped default reads a mounted file:
+encryption_key = '{{ file "/etc/platform-api/keys/encryption.key" }}'
+# or, alternatively, from an environment variable:
+# encryption_key = '{{ env "APIP_CP_ENCRYPTION_KEY" }}'
+
+# AI Workspace OIDC client secret (oidc mode) - env var, or a mounted file:
+client_secret = '{{ env "APIP_AIW_AUTH_OIDC_CLIENT_SECRET" }}'
+# client_secret = '{{ file "/secrets/ai-workspace/oidc_client_secret" }}'
+```
+
+{% endraw %}
+
+Both forms fail closed: if the variable is unset/empty, or the file is missing or outside the allowed source directories, the service refuses to start. A {% raw %}`{{ file }}`{% endraw %} path must live under an allowed directory - `/etc/ai-workspace` or `/secrets/ai-workspace` for the BFF, `/etc/platform-api` or `/secrets/platform-api` for the Platform API. Override the list with the shared `APIP_CONFIG_FILE_SOURCE_ALLOWLIST` (comma-separated; it **replaces** the defaults rather than extending them).
+
+!!! tip "Distinct from AI Workspace secrets"
+    The interpolation tokens described here configure the **services' own `config.toml`**. They are unrelated to the **AI Workspace secrets** feature - the encrypted credentials you store and reference in artifacts with {% raw %}`{{ secret "handle" }}`{% endraw %}. See [Secrets Management](./secrets-management.md) for that mechanism.
+
+## Delivering environment values
+
+For Docker Compose deployments, the sample compose delivers these values from a git-ignored `api-platform.env` via the `env_file:` directive. It uses `format: raw` so a bcrypt password hash's `$` characters are not treated as Compose interpolation:
+
+```yaml
+services:
+  platform-api:
+    env_file:
+      - path: api-platform.env
+        required: true
+        format: raw
+```
+
+`api-platform.env` is generated by the [setup script](#one-time-setup-with-setupsh). Add or edit variables there - for example, to switch the AI Workspace login mode or point at a different control plane.
+
+The stack **never auto-generates keys or certificates** and fails closed with a descriptive error at startup if a required secret is missing. Everything must be provisioned before the first start:
+
+- **TLS certificate** - the HTTPS certificate/key for the AI Workspace and Platform API listeners.
+- **RS256 JWT signing keypair** - the Platform API signs login tokens with the private key; the AI Workspace and Developer Portal verify them with the public key. There is no shared HMAC secret.
+- **At-rest encryption key** - the Platform API's 32-byte key for encrypting stored secrets, subscription tokens, and WebSub HMAC secrets at rest.
+- **Admin credentials** - the Platform API's basic-auth admin user.
+
+The setup script provisions all of these.
+
+## One-time setup with `setup.sh`
+
+The distribution ships `setup.sh`, which provisions everything a fresh stack needs. Run it once before the first `docker compose up`:
+
+```bash
+./setup.sh
+docker compose up -d
+```
+
+`setup.sh` provisions, idempotently (existing files are kept unless `--force`):
+
+| Artifact | Location | Purpose |
+|----------|----------|---------|
+| TLS certificate | `resources/certificates/cert.pem` + `key.pem` | Self-signed HTTPS pair shared by the services (mounted at `/etc/ai-workspace/tls`, `/etc/platform-api` cert paths). |
+| RS256 JWT keypair | `resources/keys/jwt_private.pem` + `jwt_public.pem` | Signs/verifies login JWTs; read by `config.toml` via a `file` token. |
+| At-rest encryption key | `resources/keys/encryption.key` | Platform API at-rest encryption key (32 bytes, 64 hex chars); read via a `file` token. **Retain it** - losing or changing it makes previously-encrypted secrets unreadable. |
+| Admin credentials | `api-platform.env` | Platform API basic-auth credential (`APIP_CP_ADMIN_USERNAME` + bcrypt `APIP_CP_ADMIN_PASSWORD_HASH`). |
+
+!!! note "Admin credentials"
+    The Platform API login is protected by basic auth. You provide the plaintext `ADMIN_USERNAME` (defaults to `admin`) and `ADMIN_PASSWORD` (used if set, otherwise prompted, otherwise randomly generated) to `setup.sh`; it writes `APIP_CP_ADMIN_USERNAME` and the **bcrypt** `APIP_CP_ADMIN_PASSWORD_HASH` into `api-platform.env` and prints the plaintext password **once** - copy it. For non-interactive use: `ADMIN_USERNAME=admin ADMIN_PASSWORD='…' ./setup.sh`.
+
+The script is **idempotent** - existing files are kept, not overwritten. Flags:
+
+| Flag | Effect |
+|------|--------|
+| `--force` | Regenerate the certificate, JWT keypair, and encryption key (rotating them) and re-provision the admin credentials (rotating the password). |
+| `--certs-only` | Generate only the TLS certificate; skip the JWT keypair, encryption key, admin credentials, and `api-platform.env`. |
+
+!!! warning "Rotating the encryption key"
+    Running `setup.sh --force` regenerates the at-rest encryption key. Data encrypted with the previous key becomes unreadable, and rotating the JWT keypair invalidates issued login tokens. Only rotate deliberately.
+
+---
+
+[← Getting Started](./getting-started.md) &nbsp;|&nbsp; [Secrets Management →](./secrets-management.md)

--- a/en/docs/next/ai-workspace/secrets-management.md
+++ b/en/docs/next/ai-workspace/secrets-management.md
@@ -361,26 +361,27 @@ The Platform API does not read the key from an environment variable directly. It
 
 {% raw %}
 ```toml
-# config.toml — resolved from the APIP_CP_ENCRYPTION_KEY environment variable
-encryption_key = '{{ env "APIP_CP_ENCRYPTION_KEY" }}'
+# config.toml - resolved from a mounted key file:
+encryption_key = '{{ file "/etc/platform-api/keys/encryption.key" }}'
 
-# Files are preferred for secrets:
-# encryption_key = '{{ file "/secrets/platform-api/encryption_key" }}'
+# Alternatively, from an environment variable:
+# encryption_key = '{{ env "APIP_CP_ENCRYPTION_KEY" }}'
 ```
 {% endraw %}
 
-For Docker Compose deployments, set `APIP_CP_ENCRYPTION_KEY` in `api-platform.env` (loaded into the container via the Compose `env_file:` directive). The AI Workspace setup script generates this key into `api-platform.env` for you (see [Getting Started](./getting-started.md)):
+For Docker Compose deployments, the AI Workspace setup script generates this key into a **file** — `resources/keys/encryption.key`, mounted into the container at `/etc/platform-api/keys` — for you (see [Getting Started](./getting-started.md)):
 
 ```sh
 ./scripts/setup.sh
 ```
 
-To set it manually instead, add the generated value to `api-platform.env`:
+To provision it manually instead, write the generated value to that file (the key is 32 bytes as 64 hex chars; a trailing newline is trimmed on load):
 
 ```sh
-# api-platform.env
-APIP_CP_ENCRYPTION_KEY=a3f1e2d4b5c6...
+openssl rand -hex 32 > resources/keys/encryption.key
 ```
 
+Or switch the token to the {% raw %}`{{ env "APIP_CP_ENCRYPTION_KEY" }}`{% endraw %} form and set the variable in `api-platform.env` instead.
+
 !!! warning
-    Use the same `APIP_CP_ENCRYPTION_KEY` across restarts and across all replicas. Changing or rotating it makes previously-encrypted secrets unreadable.
+    Use the same encryption key across restarts and across all replicas. Changing or rotating it makes previously-encrypted secrets unreadable.


### PR DESCRIPTION
This pull request updates the AI Gateway documentation to standardize authentication for management API calls. All relevant `curl` command examples now use exported environment variables (`ADMIN_USERNAME` and `ADMIN_PASSWORD`) for basic authentication, replacing hardcoded credentials and base64-encoded authorization headers. The setup instructions have also been improved to guide users to export these credentials after initial setup.

**Authentication Standardization**

* All `curl` commands for management API endpoints now use `-u "$ADMIN_USERNAME:$ADMIN_PASSWORD"` for basic authentication, replacing hardcoded `-u admin:admin` and `-H "Authorization: Basic ..."` headers across LLM provider, template, and proxy examples. [[1]](diffhunk://#diff-83f44789a76dde46d1404e8c7d1dfcc3dae63ead81e39faadcfaf6795175372dL77-R83) [[2]](diffhunk://#diff-83f44789a76dde46d1404e8c7d1dfcc3dae63ead81e39faadcfaf6795175372dL129-R135) [[3]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L301-R301) [[4]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L350-R350) [[5]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L359-R359) [[6]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L369-R369) [[7]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L390-R390) [[8]](diffhunk://#diff-af7b5df317af62819f6369e7e51386fc316f54872a8b2bd516d7df3371f12db0L411-R411) [[9]](diffhunk://#diff-d6dc48bdefbadc42dbe37574d81e6384733767b959c8fd7d7da3130ef05391c0L130-R130) [[10]](diffhunk://#diff-3bc85fdca798b45eae05f4dbeec99111b9e875079dc4c22ecbce483ce7a11dbbL121-R121) [[11]](diffhunk://#diff-2d81a76279f36679021ad88035dad75c4fee57a1b7ef45f0bf96e6370ca136f9L73-R73) [[12]](diffhunk://#diff-a4ff289c4dc6186035d6e67b9de6c9659de6b31edef7effe366fc71c5debf859L82-R82) [[13]](diffhunk://#diff-29baed6d3d2e825a4965844c1ea2f2fed6204ca3e96f0dcb80851fb299668b4bL83-R83) [[14]](diffhunk://#diff-a9ed4fc0ddacaa8b65a7a51532127a9e51618924a752220f3ac8d047d9f46747L82-R82) [[15]](diffhunk://#diff-abe1864220d3f49b4857d48e06ad19d4f1c1d46cd24d805b53886d33e45f64fbL132-R132) [[16]](diffhunk://#diff-abe1864220d3f49b4857d48e06ad19d4f1c1d46cd24d805b53886d33e45f64fbL212-R212) [[17]](diffhunk://#diff-a52f5f92435153dd943a676da6e9964d490e0fe01311e01705205277d99cd708L82-R82) [[18]](diffhunk://#diff-2667cb999e9b139f725217d8f0a9df3510283b3197e716e0688e491b6f808fd8L90-R90) [[19]](diffhunk://#diff-3bf0faffd2390e2e51be5f9c8db0fdc87f8a3c5e61522c43e9974be6d9aa73a4L73-R73) [[20]](diffhunk://#diff-97c50261e7d56d6f0c3f00836e700d77f370362e6de9cb054a759bc27c9633dfL72-R72) [[21]](diffhunk://#diff-2c480050daaff0ae456de2539f85682676631a3a981bc604566704ad5d92a066L87-R87) [[22]](diffhunk://#diff-d5fa53b3e75deb9d34c86506f72db5e6298d6665b3506ad18cb663a4d20b484dL101-R101) [[23]](diffhunk://#diff-d5fa53b3e75deb9d34c86506f72db5e6298d6665b3506ad18cb663a4d20b484dL174-R174) [[24]](diffhunk://#diff-4b9d77b973c9a610a86e185a5befc16c81c984b4c9d1244fff4628851bbc32a0L98-R98) [[25]](diffhunk://#diff-4b9d77b973c9a610a86e185a5befc16c81c984b4c9d1244fff4628851bbc32a0L171-R171) [[26]](diffhunk://#diff-17c0a2dbe41f2a1f62d23f99ed5da760910a44e20f94e554ac8fceb2402f3c7bL135-R135) [[27]](diffhunk://#diff-b75a56ba79ec7e5d6c890059d9f91d13f1d9e22f9f1d6bec1751cf9d7c832fb1L82-R88) [[28]](diffhunk://#diff-a320928df985def52a3ff04aed35e82f08ce9718e6ade46fad48d510025284f1R249-R260) [[29]](diffhunk://#diff-cbdf5277834ed0ec62f7ff75113a6344a376f9f228070f16d46f2622cd378925R413-R424)

**Improved Setup Instructions**

* The quick start guides for both LLM and MCP proxies now instruct users to export `ADMIN_USERNAME` and `ADMIN_PASSWORD` after running the setup script, using the password generated by the script. This ensures all subsequent management API calls can authenticate securely. [[1]](diffhunk://#diff-83f44789a76dde46d1404e8c7d1dfcc3dae63ead81e39faadcfaf6795175372dL59-R68) [[2]](diffhunk://#diff-b75a56ba79ec7e5d6c890059d9f91d13f1d9e22f9f1d6bec1751cf9d7c832fb1L58-R67)

**Documentation Consistency**

* Added clear explanations in deployment guides about where the management API credentials come from and how to override them if different from the defaults. [[1]](diffhunk://#diff-a320928df985def52a3ff04aed35e82f08ce9718e6ade46fad48d510025284f1R249-R260) [[2]](diffhunk://#diff-cbdf5277834ed0ec62f7ff75113a6344a376f9f228070f16d46f2622cd378925R413-R424)

Read the encryption key from a file, not an env var.
- Related to: https://github.com/wso2/api-platform/issues/2835