### PR TITLE
Add CodeRabbit config to read Claude documentation style rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: true
+  high_level_summary: false
+  high_level_summary_in_walkthrough: false
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "**/.claude/rules/*"


### PR DESCRIPTION
## Purpose

CodeRabbit doesn't read `.claude/rules/`, so the documentation style rules added in #369 aren't
applied during reviews. Verified in #374: 9 findings on a page with 30 planted violations, none
attributable to the rules.

## Checklist

N/A — no content under `en/docs/` changed.

## Goals

Make CodeRabbit apply the `.claude/rules/doc-*.md` style rules when reviewing docs PRs.

## Approach

Adds `.coderabbit.yaml` pointing `knowledge_base.code_guidelines.filePatterns` at
`**/.claude/rules/*`. Mirrors the config already in use in `wso2/api-platform`.

## Release note

N/A — internal review tooling.

## Documentation

N/A — configuration only; no published page changes.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.

## Related PRs

- #369 — adds the style rules this config points at.
- #374 — baseline test showing the rules aren't currently applied.
