### PR TITLE
Make CodeRabbit apply documentation style rules more strictly

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 language: "en-US"
 early_access: false
 reviews:
-  profile: "chill"
+  profile: "assertive"
   request_changes_workflow: true
   high_level_summary: false
   high_level_summary_in_walkthrough: false
@@ -12,6 +12,14 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+  tools:
+    languagetool:
+      level: "picky"
+  path_instructions:
+    - path: "en/docs/**/*.md"
+      instructions: >-
+        Apply the WSO2 documentation style rules in .claude/rules/doc-*.md strictly.
+        Report every violation, including low-severity ones.
 chat:
   auto_reply: true
 knowledge_base:


### PR DESCRIPTION
## Purpose

Make CodeRabbit apply the documentation style rules in `.claude/rules/`.

## Checklist

N/A — no content under `en/docs/` changed.

## Goals

Increase style-rule coverage in CodeRabbit reviews of docs PRs.

## Approach

Three changes to `.coderabbit.yaml`:
 - `profile: assertive` — stop demoting style findings to nitpicks.
 - `languagetool.level: picky` — enable formal-text rules in the linter that produces the
   existing style findings.
 - `path_instructions` for `en/docs/**/*.md` — instruct CodeRabbit to apply the rules, rather
   than relying on them as background knowledge.

## Release note

N/A — internal review tooling.

## Documentation

N/A — configuration only; no published page changes.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.

## Related PRs

- #369 — the style rules
- #374 — baseline without config
- #376 — test with config
