### PR TITLE
Give each style rule its own line for clarity

### DIFF
--- a/.claude/rules/doc-formatting-and-typography.md
+++ b/.claude/rules/doc-formatting-and-typography.md
@@ -4,6 +4,7 @@
 
 - **Sentence case, always:** only the first word plus proper nouns and acronyms. "Configure rate limiting", not "Configure Rate Limiting".
 - Descriptive and unique, so a reader can navigate by heading alone.
+- Nest levels in order: `#`, then `##`, then `###`. Never skip a level — an H3 belongs only under an H2.
 - **After a colon, semicolon, or hyphen:** capitalize only the first word, then continue lowercase — `Example 1: Basic object validation`, `Optional - Second HTTPRoute`. Don't re-capitalize every word after the mark, and don't lowercase the word right after it.
 
 ## Code font (backticks)

--- a/.claude/rules/doc-formatting-and-typography.md
+++ b/.claude/rules/doc-formatting-and-typography.md
@@ -4,7 +4,7 @@
 
 - **Sentence case, always:** only the first word plus proper nouns and acronyms. "Configure rate limiting", not "Configure Rate Limiting".
 - Descriptive and unique, so a reader can navigate by heading alone.
-- Nest levels in order: `#`, then `##`, then `###`. Never skip a level — an H3 belongs only under an H2.
+- Maintain logical order and never skip a heading level — an H3 belongs only under an H2.
 - **After a colon, semicolon, or hyphen:** capitalize only the first word, then continue lowercase — `Example 1: Basic object validation`, `Optional - Second HTTPRoute`. Don't re-capitalize every word after the mark, and don't lowercase the word right after it.
 
 ## Code font (backticks)

--- a/.claude/rules/doc-formatting-and-typography.md
+++ b/.claude/rules/doc-formatting-and-typography.md
@@ -15,7 +15,7 @@
 
 ## Emphasis and lists
 
-- **Bold:** UI element names and run-in headings, including the lead-in word of a notice. Not for emphasis in body text.
+- **Bold:** every UI element name a reader interacts with — panes, buttons, menu items, fields — plus run-in headings and the lead-in word of a notice. An unbolded UI element name is an error. Not for emphasis in body text.
 - *Italics:* two uses only — first mention of a term you define immediately after (not bold, not quotation marks), and words-as-words ("Use the word *and* instead").
 - Numbered lists when order matters, bulleted otherwise, description lists for pairs of related data.
 

--- a/.claude/rules/doc-frontmatter-and-metadata.md
+++ b/.claude/rules/doc-frontmatter-and-metadata.md
@@ -1,0 +1,28 @@
+# Rule: frontmatter and content metadata
+
+Every Markdown file under `en/docs/` needs frontmatter. AI systems and search rely on it.
+
+## Required frontmatter fields
+
+- `title` — page title, short enough not to truncate on narrow devices.
+- `description` — SEO description of the page, under 158 characters.
+- `canonical_url` — the document's canonical URL.
+- `md_url` — link to the Markdown version of the document.
+- `tags` — a list, so LLMs and agents can relate pages and concepts.
+- `author` — "WSO2 API Platform Documentation Team". For more than one, use `authors` with a list.
+- `last_updated` — `YYYY-MM-DD`.
+- `content_type` — one of `how-to`, `tutorial`, `reference`, `concept`, `explanation`, `troubleshooting`, `faq`, `release-notes`, `changelog`, `quickstart`.
+
+## Multimedia metadata
+
+- Descriptive image file names: `llm-proxy-creation-in-ai-workspace.png`, not `image1.png`.
+- Alt text on every image — see `doc-images.md`.
+- Transcripts and captions for video and audio.
+- Never put information in an image that the surrounding text doesn't also cover.
+
+## Discoverability and reuse
+
+- Keep `en/docs/llms.txt` updated.
+- Link to related topics. Don't leave a page isolated, and don't duplicate across pages.
+- Reuse section patterns: standard task steps, consistent troubleshooting layouts.
+- Audit and update pages regularly.

--- a/.claude/rules/doc-grammar-and-punctuation.md
+++ b/.claude/rules/doc-grammar-and-punctuation.md
@@ -6,7 +6,7 @@ Standard American English. Sentence case capitalization.
 - **Conditional clause first:** "If the program runs slowly, try the `--perf` flag" — not the reverse, so readers can skip the sentence when the condition doesn't apply to them.
 - **Commas:** Oxford comma before the final "and" or "or"; comma between a conditional clause and its consequence; parenthetical asides in a pair of commas.
 - **Comma splices:** never join two independent clauses with a comma — use a period.
-- **Semicolons:** only to join two complete, closely related sentences that would still make sense flipped. Comma after a transition word following one ("...; therefore, write unit tests"). In an embedded list use commas, or convert to bullets.
+- **Semicolons:** only to join two complete, closely related sentences that would still make sense flipped. Comma after a transition word following one ("…; therefore, write unit tests"). In an embedded list use commas, or convert to bullets.
 - **Em dash (—):** no space either side; use pairs to set off a digression.
 - **En dash (–):** never use one — use a hyphen or "to" instead.
 - **Hyphens:** inside compound terms (`floating-point`, `on-prem`).

--- a/.claude/rules/doc-grammar-and-punctuation.md
+++ b/.claude/rules/doc-grammar-and-punctuation.md
@@ -4,9 +4,12 @@ Standard American English. Sentence case capitalization.
 
 - **Contractions:** use common two-word ones (`you're`, `don't`, `there's`), and prefer negation contractions, since a reader scanning quickly can miss "not". Never nonstandard (`guides're`) or three-word (`mightn't've`).
 - **Conditional clause first:** "If the program runs slowly, try the `--perf` flag" — not the reverse, so readers can skip the sentence when the condition doesn't apply to them.
-- **Commas:** Oxford comma before the final "and" or "or"; comma between a conditional clause and its consequence; parenthetical asides in a pair of commas. Never join two independent clauses with a comma — use a period.
+- **Commas:** Oxford comma before the final "and" or "or"; comma between a conditional clause and its consequence; parenthetical asides in a pair of commas.
+- **Comma splices:** never join two independent clauses with a comma — use a period.
 - **Semicolons:** only to join two complete, closely related sentences that would still make sense flipped. Comma after a transition word following one ("...; therefore, write unit tests"). In an embedded list use commas, or convert to bullets.
-- **Em dash (—):** no space either side; use pairs to set off a digression. **En dash (–):** never — use a hyphen or "to". **Hyphens:** inside compound terms (`floating-point`, `on-prem`).
+- **Em dash (—):** no space either side; use pairs to set off a digression.
+- **En dash (–):** never use one — use a hyphen or "to" instead.
+- **Hyphens:** inside compound terms (`floating-point`, `on-prem`).
 - **Colons:** introduce a formal list or table only when the list isn't already the sentence's own object. "Consider the following languages: Python, Java, and C++" takes one; "My favorite languages are Python, Java, and C++" doesn't.
 - **Parentheses:** sparingly, for minor asides. Essential information doesn't belong in them. Period inside only when the whole sentence is parenthesized.
 

--- a/.claude/rules/doc-images.md
+++ b/.claude/rules/doc-images.md
@@ -24,5 +24,6 @@ Also covers image assets under `en/docs/assets/img/`.
 
 ## Layout
 
-- **High-resolution:** use `srcset` alongside `src`. The 2x image must be exactly double the 1x width and height. Set `width` in CSS pixels with no explicit `height`. Point `src` at the 1x. Never upscale a 1x to fake a 2x.
-- No inline `style` margin or alignment tweaks. Don't center or shrink images unnecessarily, and don't let them exceed the main content column width.
+- **Never use an inline `style` attribute** for margin or alignment. Don't center or shrink images unnecessarily, and don't let them exceed the main content column width.
+- **Set `width` in CSS pixels, never an explicit `height`.**
+- **High-resolution:** use `srcset` alongside `src`. The 2x image must be exactly double the 1x width and height. Point `src` at the 1x. Never upscale a 1x to fake a 2x.

--- a/.claude/rules/doc-voice-and-tone.md
+++ b/.claude/rules/doc-voice-and-tone.md
@@ -2,7 +2,8 @@
 
 - Address the reader as "you" — never "the user" or "they".
 - Products and features in third person: "this lets the API Gateway route traffic", not "this lets us route traffic".
-- Active voice, present tense, indicative or imperative mood. No subjunctive, no passive ("The request is routed by the gateway").
+- **Active voice:** the subject performs the action. Rewrite passive constructions — "the request is routed by the gateway" becomes "the gateway routes the request".
+- Present tense, indicative or imperative mood. No subjunctive.
 - Don't give software or tools human characteristics.
 - Tone: casual and approachable, yet succinct and direct — a professional acquaintance. Confident, friendly, comprehensive. Not insensitive, oversentimental, or complicated.
 
@@ -12,7 +13,9 @@
 - Marketing adjectives for capability: "powerful", "seamless", "next-generation", "effortless".
 - Jargon, buzzwords, idioms, figurative language, metaphors, ableist language.
 - Cutesiness, zaniness, pop-culture references, phrasing that denigrates any group.
-- "Let's do X". Internet slang (`tl;dr`, `ymmv`). Exclamation marks.
+- "Let's do X" — write the instruction directly instead: "Create an API", not "Let's create an API".
+- Exclamation marks.
+- Internet slang (`tl;dr`, `ymmv`).
 - Filler: "please note", "at this time".
 - The same opening phrase on every sentence (all "You can...", all "To do...").
 - Choppy or long-winded sentences.


### PR DESCRIPTION
## Purpose

Make individual style rules easier to notice and apply.

## Checklist

N/A — no content under `en/docs/` changed.

## Goals

Improve rule coverage in reviews by giving buried rules their own line.

## Approach

Six rules were packed mid-line inside longer bullets and were consistently overlooked in review.
Each now has its own bullet: comma splices, em dash, en dash, hyphens, active voice, "Let's do X",
exclamation marks, internet slang, inline `style`, and explicit `height`. The bold rule now names
which UI elements it covers. No rule was added or removed; every file stays under 30 lines.

## Release note

N/A — authoring guidelines only.

## Documentation

N/A — no published page changes.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.

## Related PRs

- #369 — adds the style rules
- #380 — review test that surfaced the overlooked rules
