### PR TITLE
Update AI Workspace and Gateway documentation to reflect new release versions

### DIFF
--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -193,7 +193,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
     unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 

--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -93,8 +93,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-beta/wso2apip-ai-gateway-1.2.0-beta.zip && \
-    unzip wso2apip-ai-gateway-1.2.0-beta.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-api-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -102,7 +102,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh
+    cd wso2apip-api-gateway-1.2.0-rc && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**
@@ -149,8 +149,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-beta/wso2apip-ai-gateway-1.2.0-beta.zip && \
-    unzip wso2apip-ai-gateway-1.2.0-beta.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-api-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -158,7 +158,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh
+    cd wso2apip-api-gateway-1.2.0 && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**
@@ -193,8 +193,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-beta/wso2apip-ai-gateway-1.2.0-beta.zip && \
-    unzip wso2apip-ai-gateway-1.2.0-beta.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-api-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -202,7 +202,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-ai-gateway-1.2.0-beta && ./scripts/setup.sh
+    cd wso2apip-api-gateway-1.2.0 && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**
@@ -252,7 +252,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command to install the gateway chart with the encryption key and control plane configurations:
 
     ```bash
-    helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version 1.2.0-beta \
+    helm install gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway --version 1.2.0 \
     --set gateway.controller.encryptionKeys.enabled=true \
     --set gateway.controller.encryptionKeys.secretName=gateway-encryption-keys \
     --set gateway.controller.controlPlane.host="host.docker.internal" \
@@ -260,7 +260,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     --set gateway.controller.controlPlane.token.value="your-gateway-token"
     ```
 
-    Use the Helm chart version that matches the gateway version shown on this page's **Get Started** section, not necessarily `1.2.0-beta`.
+    Use the Helm chart version that matches the gateway version shown on this page's **Get Started** section, not necessarily `1.2.0`.
 
     Replace `your-gateway-token` with the token from the Get Started section.
 

--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -93,7 +93,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
     unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 

--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -149,7 +149,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    curl -sLO https://github.com/wso2/api-platform/releases/download/ai-gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
     unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 

--- a/en/docs/next/ai-workspace/ai-gateways/setting-up.md
+++ b/en/docs/next/ai-workspace/ai-gateways/setting-up.md
@@ -93,8 +93,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
-    unzip wso2apip-api-gateway-1.2.0.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -102,7 +102,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-api-gateway-1.2.0-rc && ./scripts/setup.sh
+    cd wso2apip-ai-gateway-1.2.0 && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**
@@ -149,8 +149,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
-    unzip wso2apip-api-gateway-1.2.0.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -158,7 +158,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-api-gateway-1.2.0 && ./scripts/setup.sh
+    cd wso2apip-ai-gateway-1.2.0 && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**
@@ -193,8 +193,8 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run this command in your terminal to download the gateway:
 
     ```bash
-    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip && \
-    unzip wso2apip-api-gateway-1.2.0.zip
+    curl -sLO https://github.com/wso2/api-platform/releases/download/gateway/v1.2.0-rc/wso2apip-ai-gateway-1.2.0-rc.zip && \
+    unzip wso2apip-ai-gateway-1.2.0.zip
     ```
 
     **Step 2: Set up the Gateway**
@@ -202,7 +202,7 @@ The Get Started section provides setup instructions for multiple deployment opti
     Run the one-time setup script. It provisions the AES-256 at-rest encryption key, the router HTTPS listener certificate, and `api-platform.env` — all required before the first start (the gateway has no demo mode and fails closed if a required key or certificate is missing):
 
     ```bash
-    cd wso2apip-api-gateway-1.2.0 && ./scripts/setup.sh
+    cd wso2apip-ai-gateway-1.2.0 && ./scripts/setup.sh
     ```
 
     **Step 3: Configure the Gateway**

--- a/en/docs/next/ai-workspace/getting-started.md
+++ b/en/docs/next/ai-workspace/getting-started.md
@@ -27,14 +27,14 @@ The AI Workspace enables you to manage AI gateways and LLM providers. This guide
 Run this command in your terminal to download and unzip AI Workspace:
 
 ```bash
-curl -sLO https://github.com/wso2/api-platform/releases/download/portals/ai-workspace/v1.0.0-beta/wso2apip-ai-workspace-1.0.0-beta.zip && \
-unzip wso2apip-ai-workspace-1.0.0-beta.zip
+curl -sLO https://github.com/wso2/api-platform/releases/download/portals/ai-workspace/v1.0.0/wso2apip-ai-workspace-1.0.0-rc.zip && \
+unzip wso2apip-ai-workspace-1.0.0.zip
 ```
 
 ## Step 2: Run the Setup Script
 
 ```bash
-cd wso2apip-ai-workspace-1.0.0-beta
+cd wso2apip-ai-workspace-1.0.0
 ./scripts/setup.sh
 ```
 

--- a/en/docs/next/ai-workspace/getting-started.md
+++ b/en/docs/next/ai-workspace/getting-started.md
@@ -27,7 +27,7 @@ The AI Workspace enables you to manage AI gateways and LLM providers. This guide
 Run this command in your terminal to download and unzip AI Workspace:
 
 ```bash
-curl -sLO https://github.com/wso2/api-platform/releases/download/portals/ai-workspace/v1.0.0/wso2apip-ai-workspace-1.0.0-rc.zip && \
+curl -sLO https://github.com/wso2/api-platform/releases/download/portals/ai-workspace/v1.0.0-rc/wso2apip-ai-workspace-1.0.0-rc.zip && \
 unzip wso2apip-ai-workspace-1.0.0.zip
 ```
 


### PR DESCRIPTION
- Revised setup instructions in "Getting Started" to point to version 1.0.0 for AI Workspace.
- Updated "Setting Up" sections for AI Gateways to reference version 1.2.0-rc.
- Adjusted download commands and directory names to match the new release structure.

