### PR TITLE
Fix incorrect terminal commands in API Platform Documentation

### DIFF
--- a/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
+++ b/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
@@ -265,6 +265,7 @@ EOF
 ```
 
 ### Expose the data plane
+
 Identify and port forward the data-plane service (replace `<release-name>` with the actual release name).
 
 ```bash

--- a/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
+++ b/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
@@ -266,6 +266,7 @@ EOF
 
 ### Expose the data plane
 Identify and port forward the data-plane service (replace `<release-name>` with the actual release name).
+
 ```bash
 kubectl get svc
 kubectl port-forward svc/<release-name>-gateway-runtime 8080:8080 8443:8443

--- a/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
+++ b/en/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone.md
@@ -153,6 +153,8 @@ Refer to inline comments in chart `values.yaml` for all supported fields.
 
 ### Option 1: cert-manager (recommended)
 
+This assumes you haven't installed the gateway yet. If you have already installed the gateway, use "helm upgrade" instead of "helm install"
+
 ```bash
 helm install ap-gateway oci://ghcr.io/wso2/api-platform/helm-charts/gateway \
   --set gateway.controller.tls.enabled=true
@@ -213,8 +215,9 @@ kubectl port-forward svc/ap-gateway-controller 9090:9090
 ```
 
 ### Verify gateway controller admin endpoint is running
+
 ```bash
-curl http://localhost:9094/api/admin/v0.9/health
+curl -u admin:admin http://localhost:9090/api/admin/v0.9/health
 ```
 
 ### Deploy an API configuration
@@ -259,6 +262,13 @@ spec:
     - method: DELETE
       path: /books/{id}
 EOF
+```
+
+### Expose the data plane
+Identify and port forward the data-plane service (replace `<release-name>` with the actual release name).
+```bash
+kubectl get svc
+kubectl port-forward svc/<release-name>-gateway-runtime 8080:8080 8443:8443
 ```
 
 ### Test routing through the gateway


### PR DESCRIPTION
## Purpose
Found four issues in the kubernetes standalone gateway deployment guide (https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/deployment-modes/kubernetes/kubernetes-standalone/) while following the page's instructions on a local "kind" cluster and fixed them.

## Checklist
- [ ] Not applicable — no new page created, `llms.txt` unaffected
- [ ] Not applicable — no images added or changed
- [ ] Not applicable — existing frontmatter unchanged

## Goals
Make sure documented commands work exactly as written for anyone following the guide from scratch on a local development cluster, without running into errors in the terminal. 

## Approach
Fixed four command line commands in 
1. Corrected the port of the health-check example from 9094 (which wasn't mapped) to 9090.
2. Added the "-u admin:admin" flag to the same health check example because it doesn't work without this authentication. (It still doesn't work even with this authentication, but at least it gives a 404 page not found response instead of the terminal running into an error)
3.  Added a new "Expose the data plane" step before "Test routing through the gateway" step
4. Added a note clarifying that the, "helm install" sections of "Install Gateway Chart" and "TLS Configuration" must be combined into a single install, because running them one after the other would lead to a release name conflict (or run via `helm upgrade` if running sequentially). 

## User stories
As a developer following this guide for the first time, it would be nice to have all the docummented commands work as written. This would save the time wasted on figuring out and fixing these issues.

## Release note
Fixed incorrect port, missing authentication, a missing port-forward step,
and conflicting install/TLS instructions in the Kubernetes standalone
gateway deployment guide.

## Documentation
N/A — this PR *is* the documentation fix itself.

## Training
N/A — no impact on WSO2-Training content.

## Certification
N/A — no impact on certification exam content.

## Marketing
N/A — small internal doc correction, no marketing surface.

## Automation tests
- Unit tests: N/A — documentation-only change, no code.
- Integration tests: N/A — documentation-only change, no code.

## Security checks
- Followed secure coding standards: N/A (no code changed)
- Ran FindSecurityBugs plugin: N/A (no code changed)
- Confirmed this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: Yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
Windows 11, local `kind` Kubernetes cluster, `kubectl`, Helm 3.x,
gateway Helm chart `gateway-1.1.5` (`app.kubernetes.io/version: 1.1.0`),
cert-manager (Jetstack) for TLS. All four fixes verified by reproducing
the original failures, then confirming the corrected commands succeed.
 
## Learning
Every issue was found by hitting an actual command line failure while working on a personal project while following the WSO2 kubernetes standalone gateway guide step by step. And then inspecting cluster states to find the fix
