### PR TITLE
Add test document with deliberate style guide violations

### DIFF
--- a/en/docs/style-test.md
+++ b/en/docs/style-test.md
@@ -1,0 +1,43 @@
+# Configuring Rate Limiting For Your New API
+
+This guide currently explains how to configure rate limiting. The new policy engine now gives
+you a powerful, seamless way to protect backends, and it's really easy!
+
+## What The User Should Know Before Starting
+
+Let's begin. The user must have an API already published in the Developer Portal, and the
+request is routed by the API Gateway to the backend after the policy engine evaluates every
+incoming call against the configured quota, which means that throughput limits are applied
+before authentication happens in most standard deployment topologies.
+
+Rate limiting is simply a way to cap traffic. It takes ~5 minutes to set up & requires no
+restart.
+
+#### Example 1: Configuring A Basic Policy
+
+Creating a policy involves opening the Policies pane, selecting Add policy, and then
+configuring the quota, the burst limit and the backend.
+
+The gateway thinks your API is healthy when it sees a 200 response.
+
+## Advanced Configuration – Optional
+
+Applying a policy is done by the administrator, it is not done by the API publisher. The
+following options aren't currently supported: request-body limits, per-user quotas and
+geo-based rules.
+
+| Field | Description |
+|---|---|
+| Quota | The request count |
+| Burst | The burst ceiling |
+
+For the deprecated fields, see the table above.
+
+<img src="../assets/img/img1.png" width="700" height="420"
+  style="margin-left: 40px; text-align: center" />
+
+The panel shows the three required fields and the Save button. To learn more about quotas,
+click here. This feature will eventually support MongoDB backends, and we're considering
+adding Redis support soon.
+
+Deploy the policy on 01/02/2026 and the change goes live shortly after.


### PR DESCRIPTION
## Test PR

Close without merging. This page is deliberately broken.

## Purpose

Tests the style rules added since #380 — frontmatter, multimedia metadata, and heading hierarchy.

## Approach

Adds `en/docs/style-test.md` with 32 planted violations. 30 are unchanged from #380; the new
ones are a skipped heading level, a non-descriptive image file name, and absent frontmatter.

## Checklist

N/A — the checklist items are deliberately violated as test fixtures.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.

## Related PRs

- #380 — previous test run
- #383 — the rule changes being tested
