### PR TITLE
Move Quick Start Guide before Setup in API Gateway 1.1.0 nav

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -409,11 +409,11 @@ nav:
           - Gateway runtime with four CPUs: api-gateway/next/performance/gateway-runtime-with-four-cpus.md
     - "1.1.0":
         - Overview: api-gateway/1.1.0/overview.md
+        - Quick Start Guide: api-gateway/1.1.0/quick-start-guide.md
         - Setup:
           - Storage & Backends: api-gateway/1.1.0/setup/storage-and-backends.md
           - Artifact Templating: api-gateway/1.1.0/setup/artifact-templating.md
           - Upstream Timeouts: api-gateway/1.1.0/setup/upstream-timeouts.md
-        - Quick Start Guide: api-gateway/1.1.0/quick-start-guide.md
         - Policies:
           - Overview: api-gateway/1.1.0/policies/overview.md
           - Custom Policies:


### PR DESCRIPTION
## Summary

Fixes #330.

In `en/mkdocs.yml`, the API Gateway **1.1.0** version's nav section listed `Setup` before `Quick Start Guide`:

```yaml
- Overview: api-gateway/1.1.0/overview.md
- Setup:
    ...
- Quick Start Guide: api-gateway/1.1.0/quick-start-guide.md
```

The `Setup` page covers architectural details (storage & backends, artifact templating, upstream timeouts), which per the issue should come after the Quick Start rather than before it. The `next` version's nav section already has the correct order (`Overview` -> `Quick Start Guide` -> `Setup` -> `Policies` -> ...).

## Change

Reordered the `1.1.0` nav section to match the `next` version's structure: `Overview`, `Quick Start Guide`, `Setup`, then the rest unchanged.

## Test plan

- [x] Confirmed the full `mkdocs.yml` still parses as valid YAML after the change.
- [x] Confirmed the `1.1.0` nav section now reads `Overview`, `Quick Start Guide`, `Setup`, `Policies`, ... matching the `next` version's ordering.
