### PR TITLE
Enhance Docker instructions across multiple quick start guides

### DIFF
--- a/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-30
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -62,6 +65,18 @@ docker compose up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -69,12 +69,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/llm-proxy/quick-start-guide.md
@@ -84,7 +84,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
@@ -83,7 +83,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -68,12 +68,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.0.0/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-30
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -61,6 +64,18 @@ docker compose -p ai-gateway up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-02
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -62,6 +65,18 @@ docker compose up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -69,12 +69,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/llm-proxy/quick-start-guide.md
@@ -84,7 +84,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
@@ -83,7 +83,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-02
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -61,6 +64,18 @@ docker compose -p ai-gateway up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/1.1.0/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -68,12 +68,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -79,12 +79,20 @@ curl http://localhost:9094/api/admin/v1/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
@@ -94,7 +94,7 @@ curl http://localhost:9094/api/admin/v1/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/llm-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-02
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -72,6 +75,18 @@ docker compose up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/api/admin/v1/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-02
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -35,11 +35,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -71,6 +74,18 @@ docker compose -p ai-gateway up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/api/admin/v1/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -78,12 +78,20 @@ curl http://localhost:9094/api/admin/v1/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
+++ b/en/docs/ai-gateway/next/mcp-proxy/quick-start-guide.md
@@ -93,7 +93,7 @@ curl http://localhost:9094/api/admin/v1/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/api-gateway/1.0.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.0.0/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-11
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -26,10 +26,11 @@ Before you begin, ensure you have:
 
 - **wget** or **curl** installed
 - **unzip** installed
-- **Docker** installed and running
-- **Docker Compose** installed
+- A Compose-compatible container runtime, such as Docker Desktop, Podman Desktop or Podman, Rancher Desktop, Colima, or Docker Engine with the Compose plugin
 
-Verify that both `docker` and `docker compose` commands are available:
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -55,6 +56,18 @@ Navigate to the extracted directory and start the complete gateway stack using D
 cd wso2apip-api-gateway-1.1.0/
 docker compose up -d
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ### Step 3: Verify the Gateway
 

--- a/en/docs/api-gateway/1.0.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.0.0/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -60,12 +60,20 @@ docker compose up -d
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/api-gateway/1.0.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.0.0/quick-start-guide.md
@@ -75,7 +75,7 @@ docker compose up -d
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ### Step 3: Verify the Gateway
 

--- a/en/docs/api-gateway/1.1.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.1.0/quick-start-guide.md
@@ -117,7 +117,7 @@ curl -ik https://localhost:8443/reading-list/v1.0/books
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ### Stopping the Gateway
 

--- a/en/docs/api-gateway/1.1.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.1.0/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-11
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -21,11 +21,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -95,6 +98,18 @@ EOF
 curl -i http://localhost:8080/reading-list/v1.0/books
 curl -ik https://localhost:8443/reading-list/v1.0/books
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ### Stopping the Gateway
 

--- a/en/docs/api-gateway/1.1.0/quick-start-guide.md
+++ b/en/docs/api-gateway/1.1.0/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -102,12 +102,20 @@ curl -ik https://localhost:8443/reading-list/v1.0/books
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/api-gateway/next/quick-start-guide.md
+++ b/en/docs/api-gateway/next/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-11
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -21,11 +21,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -105,6 +108,18 @@ EOF
 curl -i http://localhost:8080/reading-list/v1.0/books
 curl -ik https://localhost:8443/reading-list/v1.0/books
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/api-gateway/next/quick-start-guide.md
+++ b/en/docs/api-gateway/next/quick-start-guide.md
@@ -8,7 +8,7 @@ tags:
   - quickstart
   - docker
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -112,12 +112,20 @@ curl -ik https://localhost:8443/reading-list/v1.0/books
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/api-gateway/next/quick-start-guide.md
+++ b/en/docs/api-gateway/next/quick-start-guide.md
@@ -127,7 +127,7 @@ curl -ik https://localhost:8443/reading-list/v1.0/books
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 !!! note "Running on Windows"
     The commands above assume a Linux/macOS shell. On Windows, run the one-time setup with the PowerShell script instead — it takes the same flags and provisions the same files:

--- a/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
@@ -9,7 +9,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -57,12 +57,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
@@ -72,7 +72,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/llm/quick-start-guide.md
@@ -9,7 +9,7 @@ tags:
   - llm
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-22
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -23,11 +23,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -50,6 +53,18 @@ docker compose up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an OpenAI LLM provider configuration
 

--- a/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
@@ -9,7 +9,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -58,12 +58,20 @@ curl http://localhost:9094/health
 !!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
     If the start command fails with a port binding error, identify what is already listening on the default ports:
 
+  On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:8080 -sTCP:LISTEN
     lsof -nP -iTCP:8443 -sTCP:LISTEN
     lsof -nP -iTCP:9090 -sTCP:LISTEN
     lsof -nP -iTCP:9094 -sTCP:LISTEN
     ```
+
+  On Windows PowerShell, run:
+
+  ```powershell
+  Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
+  ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 

--- a/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
@@ -9,7 +9,7 @@ tags:
   - mcp
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-06-22
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -23,11 +23,14 @@ content_type: "quickstart"
 A Docker-compatible container runtime such as:
 
 - Docker Desktop (Windows / macOS)
+- Podman Desktop or Podman (Windows / macOS / Linux)
 - Rancher Desktop (Windows / macOS)
 - Colima (macOS)
 - Docker Engine + Compose plugin (Linux)
 
-Ensure `docker` and `docker compose` commands are available.
+These examples use `docker compose`. If you use another Compose-compatible runtime, use the equivalent commands.
+
+Verify the commands for your runtime are available. For Docker:
 
 ```bash
 docker --version
@@ -51,6 +54,18 @@ docker compose -p ai-gateway up -d
 # Verify gateway controller admin endpoint is running
 curl http://localhost:9094/health
 ```
+
+!!! tip "Port 8080, 8443, 9090, or 9094 already taken?"
+    If the start command fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:8080 -sTCP:LISTEN
+    lsof -nP -iTCP:8443 -sTCP:LISTEN
+    lsof -nP -iTCP:9090 -sTCP:LISTEN
+    lsof -nP -iTCP:9094 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
+++ b/en/docs/cloud/ai-gateway/mcp/quick-start-guide.md
@@ -73,7 +73,7 @@ curl http://localhost:9094/health
   Get-NetTCPConnection -State Listen -LocalPort 8080,8443,9090,9094 | Select-Object LocalAddress, LocalPort, OwningProcess
   ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the relevant `ports:` mapping in `docker-compose.yaml`, then use the remapped host port in the verification and test commands on this page.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side value of the relevant `ports:` mapping in `docker-compose.yaml`. Then use the remapped host port in the verification and test commands on this page.
 
 ## Deploy an MCP proxy configuration
 

--- a/en/docs/next/ai-workspace/getting-started.md
+++ b/en/docs/next/ai-workspace/getting-started.md
@@ -83,7 +83,7 @@ docker compose up -d
     Get-NetTCPConnection -State Listen -LocalPort 9643,9243 | Select-Object LocalAddress, LocalPort, OwningProcess
     ```
 
-    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the `ports:` mappings in `docker-compose.yaml` before you start, for example `"9743:9643"` for AI Workspace. Open AI Workspace on the remapped host port in the next step, such as `https://localhost:9743` instead of `https://localhost:9643`. See [Change the ports AI Workspace uses](setting-up/ports.md) for the two config keys that need to match.
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host-side `ports:` mapping in `docker-compose.yaml` before you start. For example, use `"9743:9643"` for AI Workspace. Open AI Workspace on the remapped host port in the next step. For example, use `https://localhost:9743` instead of `https://localhost:9643`. See [Change the ports AI Workspace uses](setting-up/ports.md) for the two config keys that need to match.
 
 ## Step 4: Open AI Workspace
 

--- a/en/docs/next/ai-workspace/getting-started.md
+++ b/en/docs/next/ai-workspace/getting-started.md
@@ -8,7 +8,7 @@ tags:
   - ai-workspace
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-31
+last_updated: 2026-08-04
 content_type: "quickstart"
 ---
 
@@ -18,9 +18,11 @@ The AI Workspace lets you manage AI gateways and large language model (LLM) prov
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) with the Compose plugin (`docker compose version`)
+- [Docker](https://docs.docker.com/get-docker/) with the Compose plugin, or another Compose-compatible container runtime such as Podman
 - Ports **9643** and **9243** available on your machine. If either one is taken, see [Change the ports AI Workspace uses](setting-up/ports.md).
 - `curl` and `unzip` installed
+
+This guide shows commands with `docker compose`. If you use Podman or another Compose-compatible runtime, run the equivalent compose command instead, such as `podman compose up -d`.
 
 ## Step 1: Download AI Workspace
 
@@ -66,7 +68,14 @@ docker compose up -d
 ```
 
 !!! tip "Port 9643 or 9243 already taken?"
-    Change the host side of the `ports:` mappings in `docker-compose.yaml` before you start—for example `"9743:9643"` for the AI Workspace. Open AI Workspace on the remapped host port in the next step, such as `https://localhost:9743` instead of `https://localhost:9643`. See [Change the ports AI Workspace uses](setting-up/ports.md) for the two config keys that need to match.
+    If `docker compose up -d` fails with a port binding error, identify what is already listening on the default ports:
+
+    ```bash
+    lsof -nP -iTCP:9643 -sTCP:LISTEN
+    lsof -nP -iTCP:9243 -sTCP:LISTEN
+    ```
+
+    Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the `ports:` mappings in `docker-compose.yaml` before you start, for example `"9743:9643"` for AI Workspace. Open AI Workspace on the remapped host port in the next step, such as `https://localhost:9743` instead of `https://localhost:9643`. See [Change the ports AI Workspace uses](setting-up/ports.md) for the two config keys that need to match.
 
 ## Step 4: Open AI Workspace
 

--- a/en/docs/next/ai-workspace/getting-started.md
+++ b/en/docs/next/ai-workspace/getting-started.md
@@ -8,7 +8,7 @@ tags:
   - ai-workspace
   - quickstart
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-08-04
+last_updated: 2026-08-05
 content_type: "quickstart"
 ---
 
@@ -70,9 +70,17 @@ docker compose up -d
 !!! tip "Port 9643 or 9243 already taken?"
     If `docker compose up -d` fails with a port binding error, identify what is already listening on the default ports:
 
+    On macOS or Linux, run:
+
     ```bash
     lsof -nP -iTCP:9643 -sTCP:LISTEN
     lsof -nP -iTCP:9243 -sTCP:LISTEN
+    ```
+
+    On Windows PowerShell, run:
+
+    ```powershell
+    Get-NetTCPConnection -State Listen -LocalPort 9643,9243 | Select-Object LocalAddress, LocalPort, OwningProcess
     ```
 
     Stop the conflicting service if you don't need it. If you need to keep it running, change the host side of the `ports:` mappings in `docker-compose.yaml` before you start, for example `"9743:9643"` for AI Workspace. Open AI Workspace on the remapped host port in the next step, such as `https://localhost:9743` instead of `https://localhost:9643`. See [Change the ports AI Workspace uses](setting-up/ports.md) for the two config keys that need to match.


### PR DESCRIPTION
This PR updates the Compose-based quick-start docs to better cover local runtime and startup issues.

It:
- adds Compose-compatible runtime guidance, including Podman, while keeping the examples based on docker compose
- adds port-conflict troubleshooting for local startup, including how to identify processes already using the default ports and when to remap host ports
- simplifies the runtime verification wording so the prerequisite section stays concise
- fixes tip block indentation so the port-conflict guidance renders correctly inside the admonition

Scope
The update covers:
- AI Workspace getting started
- API Gateway quick starts
- AI Gateway LLM proxy quick starts
- AI Gateway MCP proxy quick starts
- Cloud AI Gateway quick starts

<img width="843" height="499" alt="Screenshot 2026-08-04 at 18 31 08" src="https://github.com/user-attachments/assets/98955592-8c69-47ae-9ed7-0b26bef897d9" />
<img width="855" height="415" alt="Screenshot 2026-08-04 at 18 31 16" src="https://github.com/user-attachments/assets/68eacd91-da6d-4f51-9ac7-1c779ff49879" />
