### PR TITLE
Update API Portal quick start and REST API base paths

### DIFF
--- a/en/docs/next/api-portal/about-this-release.md
+++ b/en/docs/next/api-portal/about-this-release.md
@@ -25,8 +25,8 @@ For more information on the API Portal & MCP Hub, see the [overview](overview.md
 Download the standalone distribution from the WSO2 API Platform release page:
 
 ```bash
-curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc2/wso2apip-api-portal-1.0.0-rc2.zip && \
-unzip wso2apip-api-portal-1.0.0-rc2.zip
+curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc3/wso2apip-api-portal-1.0.0-rc3.zip && \
+unzip wso2apip-api-portal-1.0.0-rc3.zip
 ```
 
 To install and run it, follow the [Getting started](getting-started.md) guide.

--- a/en/docs/next/api-portal/admin-settings/llm-instructions.md
+++ b/en/docs/next/api-portal/admin-settings/llm-instructions.md
@@ -62,7 +62,7 @@ The pane beside the fields renders the `llms.txt` your settings produce, and ref
 To fetch it yourself:
 
 ```text
-GET /{orgName}/views/{viewName}/llms.txt
+GET /api-portal/{orgName}/views/{viewName}/llms.txt
 ```
 
 The generated file lists each agent-visible artifact under its own section:

--- a/en/docs/next/api-portal/admin-settings/manage-views.md
+++ b/en/docs/next/api-portal/admin-settings/manage-views.md
@@ -14,7 +14,7 @@ content_type: "how-to"
 
 # Manage views
 
-A **view** is a filtered, branded subset of an organization's APIs—for example, `public` for external developers and `internal` for internal teams. Each view has its own URL (`/api-portal/<orgHandle>/views/<viewName>`) and shows only the APIs tagged with its assigned labels. [LLM Instructions](llm-instructions.md) and [API Workflows](managing-api-workflows.md) are also configured per view.
+A **view** is a filtered, branded subset of APIs—for example, `public` for external developers and `internal` for internal teams. Each view has its own URL (`/api-portal/<orgHandle>/views/<viewName>`) and shows only the APIs tagged with its assigned labels. [LLM Instructions](llm-instructions.md) and [API Workflows](managing-api-workflows.md) are also configured per view.
 
 ## Adding a view
 

--- a/en/docs/next/api-portal/admin-settings/manage-views.md
+++ b/en/docs/next/api-portal/admin-settings/manage-views.md
@@ -14,7 +14,7 @@ content_type: "how-to"
 
 # Manage views
 
-A **view** is a filtered, branded subset of an organization's APIs—for example, `public` for external developers and `internal` for internal teams. Each view has its own URL (`/<orgHandle>/views/<viewName>`) and shows only the APIs tagged with its assigned labels. [LLM Instructions](llm-instructions.md) and [API Workflows](managing-api-workflows.md) are also configured per view.
+A **view** is a filtered, branded subset of an organization's APIs—for example, `public` for external developers and `internal` for internal teams. Each view has its own URL (`/api-portal/<orgHandle>/views/<viewName>`) and shows only the APIs tagged with its assigned labels. [LLM Instructions](llm-instructions.md) and [API Workflows](managing-api-workflows.md) are also configured per view.
 
 ## Adding a view
 

--- a/en/docs/next/api-portal/admin-settings/organization-settings.md
+++ b/en/docs/next/api-portal/admin-settings/organization-settings.md
@@ -25,7 +25,7 @@ The **Organization** tab in the API Portal's Settings page manages the details o
 | Field | Description |
 |---|---|
 | **Name** | The display name shown throughout the portal UI |
-| **Handle** | The URL-safe identifier used in every portal URL (`/<orgHandle>/views/<viewName>`). Read-only—it can't be changed after the organization is created |
+| **Handle** | The URL-safe identifier used in every portal URL (`/api-portal/<orgHandle>/views/<viewName>`). Read-only—it can't be changed after the organization is created |
 | **Artifact types served** | Read-only. Shows which artifact types the portal serves—APIs, Model Context Protocol (MCP) servers, and API workflows. Set by the operator in the `[api_portal.artifacts]` config, not from this pane; pages for a type that isn't served return 404. See [Artifact types](../artifact-types.md) |
 | **Business owner** | Contact name for the organization owner |
 | **Business owner contact** | The owner's phone number or other contact string |

--- a/en/docs/next/api-portal/api-workflows.md
+++ b/en/docs/next/api-portal/api-workflows.md
@@ -78,7 +78,7 @@ An agent that hasn't been handed a prompt finds workflows through the portal's m
 | Endpoint | Returns |
 |---|---|
 | `/api-portal/{orgName}/views/{viewName}/llms.txt` | The portal index. Its **API Workflows** section lists every agent-visible workflow with its description, each linking to the workflow's own Markdown |
-| `/api-portal/{orgName}/views/{viewName}/api-workflows.md` | A Markdown list of every agent-visible workflow, each linking to `/api-workflows/{handle}.md` |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows.md` | A Markdown list of every agent-visible workflow, each linking to `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}.md` |
 | `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}.md` | One workflow in Markdown. For an Arazzo workflow: status, description, source APIs linked to their documentation, guidance on each source's authentication, and the full Arazzo specification inlined. For a Markdown workflow: the content the admin authored, as written |
 | `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json` | The raw Arazzo specification. Returns `404` for a Markdown-authored workflow |
 | `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/prompt` | A JSON object with the workflow's agent prompt, description, raw content, and source APIs |

--- a/en/docs/next/api-portal/api-workflows.md
+++ b/en/docs/next/api-portal/api-workflows.md
@@ -47,7 +47,7 @@ An Arazzo workflow opens with its description above the interactive viewer:
 An Arazzo workflow names its source APIs in `sourceDescriptions`. Those are the APIs you'll be calling, and each one's own documentation gives you the base URL, the operations, and the authentication it expects. To fetch the raw specification for tooling that reads Arazzo, request it directly:
 
 ```text
-GET /{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json
+GET /api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json
 ```
 
 ## Hand a workflow to an AI agent
@@ -77,11 +77,11 @@ An agent that hasn't been handed a prompt finds workflows through the portal's m
 
 | Endpoint | Returns |
 |---|---|
-| `/{orgName}/views/{viewName}/llms.txt` | The portal index. Its **API Workflows** section lists every agent-visible workflow with its description, each linking to the workflow's own Markdown |
-| `/{orgName}/views/{viewName}/api-workflows.md` | A Markdown list of every agent-visible workflow, each linking to `/api-workflows/{handle}.md` |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}.md` | One workflow in Markdown. For an Arazzo workflow: status, description, source APIs linked to their documentation, guidance on each source's authentication, and the full Arazzo specification inlined. For a Markdown workflow: the content the admin authored, as written |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json` | The raw Arazzo specification. Returns `404` for a Markdown-authored workflow |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}/prompt` | A JSON object with the workflow's agent prompt, description, raw content, and source APIs |
+| `/api-portal/{orgName}/views/{viewName}/llms.txt` | The portal index. Its **API Workflows** section lists every agent-visible workflow with its description, each linking to the workflow's own Markdown |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows.md` | A Markdown list of every agent-visible workflow, each linking to `/api-workflows/{handle}.md` |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}.md` | One workflow in Markdown. For an Arazzo workflow: status, description, source APIs linked to their documentation, guidance on each source's authentication, and the full Arazzo specification inlined. For a Markdown workflow: the content the admin authored, as written |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json` | The raw Arazzo specification. Returns `404` for a Markdown-authored workflow |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/prompt` | A JSON object with the workflow's agent prompt, description, raw content, and source APIs |
 
 A typical agent flow is: read `llms.txt` or `api-workflows.md` to see what exists, fetch `{handle}.md` for the workflow that matches the task, follow its links to each source API's documentation for endpoints and security schemes, then execute the steps in order, passing outputs between them.
 

--- a/en/docs/next/api-portal/concepts.md
+++ b/en/docs/next/api-portal/concepts.md
@@ -104,7 +104,7 @@ An **API key** is a simple token bound to a specific API or MCP server, used to 
 API keys can be generated, regenerated (rotated), or revoked. Each of those publishes a webhook event, so a handler in front of your API Gateway can enforce the change once it receives the event—see the [Webhook Event Catalog](references/webhook-event-catalog.md). See [Manage API Keys](manage-api-keys.md).
 
 !!! note
-    The portal generates keys through the UI for REST, WebSocket, and WebSub APIs whose definition declares API-key security. Keys for GraphQL and SOAP APIs exist solely through the [API Keys](rest-api/api-keys.md) Management API, and keys for MCP servers through [MCP Server Keys](rest-api/mcp-server-keys.md).
+    The portal generates keys through the UI for REST, WebSocket, and WebSub APIs whose definition declares API-key security. Keys for GraphQL and SOAP APIs exist solely through the [API Keys](rest-api/api-keys.md) Management API. Keys for MCP servers exist only through the [MCP Server Keys](rest-api/mcp-server-keys.md) Management API.
 
 ## OAuth2 credentials
 

--- a/en/docs/next/api-portal/concepts.md
+++ b/en/docs/next/api-portal/concepts.md
@@ -104,7 +104,7 @@ An **API key** is a simple token bound to a specific API or MCP server, used to 
 API keys can be generated, regenerated (rotated), or revoked. Each of those publishes a webhook event, so a handler in front of your API Gateway can enforce the change once it receives the event—see the [Webhook Event Catalog](references/webhook-event-catalog.md). See [Manage API Keys](manage-api-keys.md).
 
 !!! note
-    The portal generates keys through the UI for REST and WebSocket APIs only. Keys for GraphQL and SOAP APIs exist solely through the [API Keys](rest-api/api-keys.md) Management API, and keys for MCP servers through [MCP Server Keys](rest-api/mcp-server-keys.md).
+    The portal generates keys through the UI for REST, WebSocket, and WebSub APIs whose definition declares API-key security. Keys for GraphQL and SOAP APIs exist solely through the [API Keys](rest-api/api-keys.md) Management API, and keys for MCP servers through [MCP Server Keys](rest-api/mcp-server-keys.md).
 
 ## OAuth2 credentials
 

--- a/en/docs/next/api-portal/concepts.md
+++ b/en/docs/next/api-portal/concepts.md
@@ -25,7 +25,7 @@ The database schema itself is multi-organization—one shared database can hold 
 The handle appears in every portal URL:
 
 ```
-https://<host>/<orgHandle>/views/<viewName>
+https://<host>/api-portal/<orgHandle>/views/<viewName>
 ```
 
 In local-auth mode it must match the organization ID the Platform API asserts in the `org_handle` claim. In IDP mode the token's organization claim has to resolve to this same handle. See [Connect an identity provider](setting-up/authentication/connect-an-identity-provider.md#step-5-make-the-organization-claim-resolve-to-your-organization).
@@ -37,7 +37,7 @@ A **view** is a filtered, branded subset of the organization's APIs and Model Co
 Each view has its own URL:
 
 ```
-https://<host>/<orgHandle>/views/<viewName>
+https://<host>/api-portal/<orgHandle>/views/<viewName>
 ```
 
 See [Manage Views](admin-settings/manage-views.md).

--- a/en/docs/next/api-portal/consume-an-api/api-key.md
+++ b/en/docs/next/api-portal/consume-an-api/api-key.md
@@ -22,7 +22,7 @@ An API key is bound to one API or MCP server. You generate it from that artifact
 - You have a key. See [Manage API Keys](../manage-api-keys.md) for the generate, rotate, and revoke lifecycle.
 
     !!! note
-        The portal generates keys for REST and WebSocket APIs only. GraphQL, SOAP, and MCP artifacts get no **API Keys** button even when their specification declares an `apiKey` scheme—for those, obtain the key from whoever operates the API and send it the same way.
+        The portal generates keys for REST, WebSocket, and WebSub APIs only. GraphQL, SOAP, and MCP artifacts get no **API Keys** button even when their specification declares an `apiKey` scheme—for those, obtain the key from whoever operates the API and send it the same way.
 
 - If the API has subscription plans, [subscribe to one](../manage-subscriptions.md). The subscription is a separate credential from the key, and you send both.
 

--- a/en/docs/next/api-portal/consume-an-api/api-key.md
+++ b/en/docs/next/api-portal/consume-an-api/api-key.md
@@ -14,7 +14,7 @@ content_type: "how-to"
 
 # Consume an API secured with an API key
 
-An API key is bound to one API or MCP server. You generate it from that artifact's own **API Keys** page, and it authenticates your requests to that artifact only. No key manager is involved, and an application is optional—you can associate a key with one for usage analytics, which changes nothing about how the key works.
+An API key is bound to one API or Model Context Protocol (MCP) server. You generate it from that artifact's own **API Keys** page, and it authenticates your requests to that artifact only. No key manager is involved, and an application is optional—you can associate a key with one for usage analytics, which changes nothing about how the key works.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ An API key is bound to one API or MCP server. You generate it from that artifact
 - You have a key. See [Manage API Keys](../manage-api-keys.md) for the generate, rotate, and revoke lifecycle.
 
     !!! note
-        The portal generates keys for REST, WebSocket, and WebSub APIs only. GraphQL, SOAP, and MCP artifacts get no **API Keys** button even when their specification declares an `apiKey` scheme—for those, obtain the key from whoever operates the API and send it the same way.
+        The portal generates keys for REST, WebSocket, and WebSub APIs whose specification declares API key security. GraphQL, SOAP, and MCP artifacts get no **API Keys** button even when their specification declares an `apiKey` scheme—for those, obtain the key from whoever operates the API and send it the same way.
 
 - If the API has subscription plans, [subscribe to one](../manage-subscriptions.md). The subscription is a separate credential from the key, and you send both.
 

--- a/en/docs/next/api-portal/consume-an-api/overview.md
+++ b/en/docs/next/api-portal/consume-an-api/overview.md
@@ -38,7 +38,7 @@ Two shortcuts on the API's [overview page](../discover-apis/api-overview.md) tel
 - An **API Keys** button appears for REST, WebSocket, and WebSub APIs whose specification declares API key security. The portal offers no key generation in the UI for GraphQL, SOAP, or MCP artifacts, even when their specification declares an `apiKey` scheme. For those, use the Management API: [API Keys](../rest-api/api-keys.md) for GraphQL and SOAP APIs, and [MCP Server Keys](../rest-api/mcp-server-keys.md) for MCP servers.
 - A **Subscription plans** panel appears only for APIs with plans, which is what a subscription token comes from.
 
-The per-API Markdown document at `/{orgName}/views/{viewName}/api/{apiHandle}.md` spells out the authentication steps in prose, generated from the same specification. It's the quickest read of the three.
+The per-API Markdown document at `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}.md` spells out the authentication steps in prose, generated from the same specification. It's the quickest read of the three.
 
 ## Get each credential
 

--- a/en/docs/next/api-portal/consume-an-api/overview.md
+++ b/en/docs/next/api-portal/consume-an-api/overview.md
@@ -38,7 +38,7 @@ Two shortcuts on the API's [overview page](../discover-apis/api-overview.md) tel
 - An **API Keys** button appears for REST, WebSocket, and WebSub APIs whose specification declares API key security. The portal offers no key generation in the UI for GraphQL, SOAP, or MCP artifacts, even when their specification declares an `apiKey` scheme. For those, use the Management API: [API Keys](../rest-api/api-keys.md) for GraphQL and SOAP APIs, and [MCP Server Keys](../rest-api/mcp-server-keys.md) for MCP servers.
 - A **Subscription plans** panel appears only for APIs with plans, which is what a subscription token comes from.
 
-The per-API Markdown document at `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}.md` spells out the authentication steps in prose, generated from the same specification. It's the quickest read of the three.
+The per-API Markdown document at `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}.md` spells out the authentication steps in prose, generated from the same specification. It states those steps directly, so you don't cross-reference the specification yourself.
 
 ## Get each credential
 

--- a/en/docs/next/api-portal/consume-an-api/overview.md
+++ b/en/docs/next/api-portal/consume-an-api/overview.md
@@ -35,7 +35,7 @@ Read the API's own specification—it's authoritative, and the portal derives it
 
 Two shortcuts on the API's [overview page](../discover-apis/api-overview.md) tell you the same thing faster:
 
-- An **API Keys** button appears for REST and WebSocket APIs whose specification declares API key security. The portal offers no key generation in the UI for GraphQL, SOAP, or MCP artifacts, even when their specification declares an `apiKey` scheme. For those, use the Management API: [API Keys](../rest-api/api-keys.md) for GraphQL and SOAP APIs, and [MCP Server Keys](../rest-api/mcp-server-keys.md) for MCP servers.
+- An **API Keys** button appears for REST, WebSocket, and WebSub APIs whose specification declares API key security. The portal offers no key generation in the UI for GraphQL, SOAP, or MCP artifacts, even when their specification declares an `apiKey` scheme. For those, use the Management API: [API Keys](../rest-api/api-keys.md) for GraphQL and SOAP APIs, and [MCP Server Keys](../rest-api/mcp-server-keys.md) for MCP servers.
 - A **Subscription plans** panel appears only for APIs with plans, which is what a subscription token comes from.
 
 The per-API Markdown document at `/{orgName}/views/{viewName}/api/{apiHandle}.md` spells out the authentication steps in prose, generated from the same specification. It's the quickest read of the three.

--- a/en/docs/next/api-portal/discover-apis/ai-agent-discovery.md
+++ b/en/docs/next/api-portal/discover-apis/ai-agent-discovery.md
@@ -27,7 +27,7 @@ The portal generates an `llms.txt` file on every request—a Markdown index desi
 **Endpoint:**
 
 ```text
-GET /{orgName}/views/{viewName}/llms.txt
+GET /api-portal/{orgName}/views/{viewName}/llms.txt
 ```
 
 The file opens with the portal's name and description, both configured through [LLM Instructions](../admin-settings/llm-instructions.md). It then lists every agent-visible artifact, grouped into the following sections, with each entry linking to that artifact's own Markdown document:
@@ -54,17 +54,17 @@ Beyond `llms.txt`, the portal serves its catalog, documentation, and specificati
 
 | Endpoint | Description |
 |---|---|
-| `/{orgName}/views/{viewName}/apis.md` | Every agent-visible API, grouped by type, as a single Markdown document |
-| `/{orgName}/views/{viewName}/mcps.md` | Every agent-visible MCP server as a single Markdown document |
+| `/api-portal/{orgName}/views/{viewName}/apis.md` | Every agent-visible API, grouped by type, as a single Markdown document |
+| `/api-portal/{orgName}/views/{viewName}/mcps.md` | Every agent-visible MCP server as a single Markdown document |
 
 ### Per-API and per-MCP-server documentation
 
 | Endpoint | Description |
 |---|---|
-| `/{orgName}/views/{viewName}/api/{apiHandle}.md` | Full documentation for one API, in Markdown |
-| `/{orgName}/views/{viewName}/mcp/{apiHandle}.md` | Full documentation for one MCP server, in Markdown |
-| `/{orgName}/views/{viewName}/api/{apiHandle}/docs/{docType}/{docName}.md` | One attached document, as the raw Markdown the publisher uploaded |
-| `/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/{docType}/{docName}.md` | The same, for an MCP server |
+| `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}.md` | Full documentation for one API, in Markdown |
+| `/api-portal/{orgName}/views/{viewName}/mcp/{apiHandle}.md` | Full documentation for one MCP server, in Markdown |
+| `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}/docs/{docType}/{docName}.md` | One attached document, as the raw Markdown the publisher uploaded |
+| `/api-portal/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/{docType}/{docName}.md` | The same, for an MCP server |
 
 A per-API Markdown document is self-contained. It carries:
 
@@ -82,11 +82,11 @@ The specification format follows the API type, so each API serves exactly one ex
 
 | API type | Endpoint | Format |
 |---|---|---|
-| REST | `/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.json` | OpenAPI (JSON) |
-| WebSocket, WebSub | `/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.json` | AsyncAPI (JSON) |
-| GraphQL | `/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.graphql` | GraphQL schema (SDL) |
-| SOAP | `/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.xml` | WSDL (XML) |
-| MCP server | `/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/specification.json` | Tool, resource, and prompt schema (JSON) |
+| REST | `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.json` | OpenAPI (JSON) |
+| WebSocket, WebSub | `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.json` | AsyncAPI (JSON) |
+| GraphQL | `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.graphql` | GraphQL schema (SDL) |
+| SOAP | `/api-portal/{orgName}/views/{viewName}/api/{apiHandle}/docs/specification.xml` | WSDL (XML) |
+| MCP server | `/api-portal/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/specification.json` | Tool, resource, and prompt schema (JSON) |
 
 For REST, WebSocket, and WebSub APIs, the portal substitutes the API's live production and sandbox URLs into the specification it serves, so an agent doesn't have to resolve placeholder server entries.
 
@@ -94,10 +94,10 @@ For REST, WebSocket, and WebSub APIs, the portal substitutes the API's live prod
 
 | Endpoint | Description |
 |---|---|
-| `/{orgName}/views/{viewName}/api-workflows.md` | Every published, agent-visible workflow as a single Markdown document |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}.md` | One workflow rendered as Markdown, including its steps and links to the APIs it calls |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json` | The raw [Arazzo](https://spec.openapis.org/arazzo/latest.html) specification for one workflow |
-| `/{orgName}/views/{viewName}/api-workflows/{handle}/prompt` | A JSON object holding the workflow's agent prompt, description, raw content, and source APIs |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows.md` | Every published, agent-visible workflow as a single Markdown document |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}.md` | One workflow rendered as Markdown, including its steps and links to the APIs it calls |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/arazzo.json` | The raw [Arazzo](https://spec.openapis.org/arazzo/latest.html) specification for one workflow |
+| `/api-portal/{orgName}/views/{viewName}/api-workflows/{handle}/prompt` | A JSON object holding the workflow's agent prompt, description, raw content, and source APIs |
 
 The `arazzo.json` endpoint returns `404` for a non-Arazzo workflow.
 

--- a/en/docs/next/api-portal/discover-apis/api-overview.md
+++ b/en/docs/next/api-portal/discover-apis/api-overview.md
@@ -38,7 +38,7 @@ The header shows the API's icon, name, version, and description, along with tags
 - **Subscribe**: jumps down to the subscription plans. Shown when the API has plans and you aren't subscribed to one yet
 - **Documentation**: opens the API's full documentation. SOAP APIs show a **Download** button for the WSDL file instead
 - **Try with AI**: opens a modal with a ready-made prompt that briefs an AI agent on the API, using its [machine-readable documentation](ai-agent-discovery.md). Shown when the API is agent-visible. From the modal you can copy the prompt, download it as a `.txt` file, or send it straight to an assistant with **Run in Claude**.
-- **API Keys**: opens the API Keys page, where you generate a key. Shown for REST and WebSocket APIs whose specification declares API key security, and never for GraphQL, SOAP, or MCP artifacts.
+- **API Keys**: opens the API Keys page, where you generate a key. Shown for REST, WebSocket, and WebSub APIs whose specification declares API key security, and never for GraphQL, SOAP, or MCP artifacts.
 
 ### Page sections
 

--- a/en/docs/next/api-portal/getting-started.md
+++ b/en/docs/next/api-portal/getting-started.md
@@ -78,7 +78,7 @@ curl -fk https://localhost:9243/health
 Navigate to:
 
 ```
-https://localhost:9543/default/views/default
+https://localhost:9543/api-portal/default/views/default
 ```
 
 You'll see the API Portal home page.
@@ -113,7 +113,7 @@ To publish an API of your own instead, continue below.
 
 ## Step 6: Publish your first API
 
-Publish an API by uploading a manifest and an OpenAPI definition. This example uses the **Reading List API**, whose backend is already hosted, so it works without deploying a gateway of your own.
+Publish an API by uploading a manifest and an OpenAPI definition. This example uses a **Books API**, whose backend is already hosted, so it works without deploying a gateway of your own.
 
 Create the API manifest:
 
@@ -123,15 +123,15 @@ apiVersion: api-portal.api-platform.wso2.com/v1
 kind: RestApi
 
 metadata:
-  name: reading-list-api-v1.0
+  name: books-api-v1.0
 
 spec:
   type: REST
-  displayName: Reading List API
+  displayName: Books API
   version: v1.0
   description: Sample reading-list API for tracking books and their reading status. Open access — no API key or subscription required.
   status: PUBLISHED
-  referenceId: reading-list-api-v1.0
+  referenceId: books-api-v1.0
 
   tags:
     - reading-list
@@ -163,7 +163,7 @@ Create the OpenAPI definition:
 # definition.yaml
 openapi: 3.0.1
 info:
-  title: Reading List API
+  title: Books API
   version: v1.0
   description: |
     Track a personal reading list — add books, update their reading status, and
@@ -234,13 +234,13 @@ TOKEN=$(curl -sk -X POST "https://localhost:9243/api/portal/v0.9/auth/login" \
   -d "username=<admin-username>&password=<admin-password>" | jq -r .token)
 
 # Publish the API — the login is scoped to the "default" organization
-curl -k -X POST "https://localhost:9543/api/v0.9/apis" \
+curl -k -X POST "https://localhost:9543/api-portal/api/v0.9/apis" \
   -H "Authorization: Bearer $TOKEN" \
   -F "metadata=@api.yaml;type=application/yaml" \
   -F "definition=@definition.yaml;type=application/yaml"
 ```
 
-Refresh the portal—the Reading List API now appears in the catalog. Click it to view its documentation and try-out console.
+Refresh the portal—the Books API now appears in the catalog. Click it to view its documentation and try-out console.
 
 ## What's next
 

--- a/en/docs/next/api-portal/getting-started.md
+++ b/en/docs/next/api-portal/getting-started.md
@@ -113,7 +113,7 @@ To publish an API of your own instead, continue below.
 
 ## Step 6: Publish your first API
 
-Publish an API by uploading a manifest and an OpenAPI definition. This example uses a **Books API**, whose backend is already hosted, so it works without deploying a gateway of your own.
+Publish an API by uploading a manifest and an OpenAPI definition. This example uses a Books API, whose backend is already hosted, so it works without deploying a gateway of your own.
 
 Create the API manifest:
 
@@ -240,7 +240,7 @@ curl -k -X POST "https://localhost:9543/api-portal/api/v0.9/apis" \
   -F "definition=@definition.yaml;type=application/yaml"
 ```
 
-Refresh the portal—the Books API now appears in the catalog. Click it to view its documentation and try-out console.
+Refresh the portal—the **Books API** now appears in the catalog. Select the **Books API** card to open its documentation and **Try It** console.
 
 ## What's next
 

--- a/en/docs/next/api-portal/getting-started.md
+++ b/en/docs/next/api-portal/getting-started.md
@@ -28,8 +28,8 @@ The API Portal & MCP Hub is where developers discover, subscribe to, and consume
 Run this command in your terminal to download and unzip the standalone API Portal distribution:
 
 ```bash
-curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc2/wso2apip-api-portal-1.0.0-rc2.zip && \
-unzip wso2apip-api-portal-1.0.0-rc2.zip
+curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc3/wso2apip-api-portal-1.0.0-rc3.zip && \
+unzip wso2apip-api-portal-1.0.0-rc3.zip
 ```
 
 ## Step 2: Run the setup script

--- a/en/docs/next/api-portal/mcp-servers/discover-mcp-servers.md
+++ b/en/docs/next/api-portal/mcp-servers/discover-mcp-servers.md
@@ -75,9 +75,9 @@ Every MCP server in the catalog is exposed through the portal's machine-readable
 
 | Endpoint | Returns |
 |---|---|
-| `/{orgName}/views/{viewName}/mcps.md` | Every agent-visible MCP server as one Markdown document |
-| `/{orgName}/views/{viewName}/mcp/{apiHandle}.md` | One server in Markdown: metadata, plans, attached documents, and its full tool, resource, and prompt list |
-| `/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/specification.json` | The raw tool, resource, and prompt schema |
+| `/api-portal/{orgName}/views/{viewName}/mcps.md` | Every agent-visible MCP server as one Markdown document |
+| `/api-portal/{orgName}/views/{viewName}/mcp/{apiHandle}.md` | One server in Markdown: metadata, plans, attached documents, and its full tool, resource, and prompt list |
+| `/api-portal/{orgName}/views/{viewName}/mcp/{apiHandle}/docs/specification.json` | The raw tool, resource, and prompt schema |
 
 Servers also appear in the portal's `llms.txt` index, under an **MCPs** section. See [AI Agent Discovery](../discover-apis/ai-agent-discovery.md).
 

--- a/en/docs/next/api-portal/mcp-servers/mcp-registry.md
+++ b/en/docs/next/api-portal/mcp-servers/mcp-registry.md
@@ -24,8 +24,8 @@ A server published through the registry becomes an ordinary catalog artifact: it
 Every endpoint is scoped to an organization handle, and two mount paths serve the same router:
 
 ```text
-/registry/{orgHandle}/v0.1/...
-/{orgHandle}/registry/v0.1/...
+/api-portal/registry/{orgHandle}/v0.1/...
+/api-portal/{orgHandle}/registry/v0.1/...
 ```
 
 Requests naming an organization this instance doesn't serve get a JSON `404`. Responses are JSON throughout, including errors, which take the shape `{"error": "..."}`.
@@ -39,7 +39,7 @@ These three need no authentication.
 ### List servers
 
 ```text
-GET /registry/{orgHandle}/v0.1/servers
+GET /api-portal/registry/{orgHandle}/v0.1/servers
 ```
 
 Four query parameters control paging and filtering:
@@ -68,7 +68,7 @@ Servers come back newest-published first, with servers that have no publish time
 ### List a server's versions
 
 ```text
-GET /registry/{orgHandle}/v0.1/servers/{serverName}/versions
+GET /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions
 ```
 
 Returns every version of one server, newest first. `include_deleted` works as above. URL-encode the slash in `{serverName}`—`example.com/travel-assistant` becomes `example.com%2Ftravel-assistant`.
@@ -76,7 +76,7 @@ Returns every version of one server, newest first. `include_deleted` works as ab
 ### Get one version
 
 ```text
-GET /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
+GET /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
 ```
 
 Returns a single version, including its tools, resources, and prompts. Deleted versions return `404` unless you pass `include_deleted=true`.
@@ -125,16 +125,16 @@ These require a bearer token or an authenticated local-auth session, and the sam
 
 | Endpoint | Scope |
 |---|---|
-| `POST /registry/{orgHandle}/v0.1/publish` | `dp:mcp_server:create` to create, `dp:mcp_server:update` to update |
-| `PUT /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}` | `dp:mcp_server:update` |
-| `DELETE /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}` | `dp:mcp_server:delete` |
-| `PATCH /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}/status` | `dp:mcp_server:update` |
-| `PATCH /registry/{orgHandle}/v0.1/servers/{serverName}/status` | `dp:mcp_server:update` |
+| `POST /api-portal/registry/{orgHandle}/v0.1/publish` | `dp:mcp_server:create` to create, `dp:mcp_server:update` to update |
+| `PUT /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}` | `dp:mcp_server:update` |
+| `DELETE /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}` | `dp:mcp_server:delete` |
+| `PATCH /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}/status` | `dp:mcp_server:update` |
+| `PATCH /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/status` | `dp:mcp_server:update` |
 
 ### Publish a server
 
 ```text
-POST /registry/{orgHandle}/v0.1/publish
+POST /api-portal/registry/{orgHandle}/v0.1/publish
 ```
 
 `publish` is an upsert, keyed on the server name and version. It returns `201` when it creates a server and `200` when it updates one—and it checks the scope for the operation it's actually about to perform, so a token holding only `dp:mcp_server:create` gets `403` when the target version already exists.
@@ -178,7 +178,7 @@ Newly published servers are mapped to the `default` label, so they appear in eve
 ### Update a version
 
 ```text
-PUT /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
+PUT /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
 ```
 
 Takes the same body as `publish`, and the `version` field in the body has to match the one in the path—a mismatch returns `400`.
@@ -186,7 +186,7 @@ Takes the same body as `publish`, and the `version` field in the body has to mat
 ### Delete a version
 
 ```text
-DELETE /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
+DELETE /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}
 ```
 
 A soft delete. The version's status becomes `deleted` and it drops out of the discovery endpoints unless you ask for `include_deleted=true`. The row itself stays.
@@ -194,8 +194,8 @@ A soft delete. The version's status becomes `deleted` and it drops out of the di
 ### Change status
 
 ```text
-PATCH /registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}/status
-PATCH /registry/{orgHandle}/v0.1/servers/{serverName}/status
+PATCH /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/versions/{version}/status
+PATCH /api-portal/registry/{orgHandle}/v0.1/servers/{serverName}/status
 ```
 
 Both take `{"status": "active" | "deprecated" | "deleted"}`. The first changes one version; the second changes every version of the server at once. Any other value returns `400`, and so does setting a version to the status it already has.
@@ -206,7 +206,7 @@ The portal exposes MCP servers through two different APIs, and they aren't inter
 
 | | MCP Registry API | [Management API](../rest-api/mcp-servers.md) |
 |---|---|---|
-| Path | `/registry/{orgHandle}/v0.1` | `/api/v0.9` |
+| Path | `/api-portal/registry/{orgHandle}/v0.1` | `/api-portal/api/v0.9` |
 | Shape | Model Context Protocol registry specification | The portal's own resource model |
 | Discovery auth | None | Bearer token |
 | Identified by | Reverse-DNS name plus version | Portal handle |

--- a/en/docs/next/api-portal/references/configurations.md
+++ b/en/docs/next/api-portal/references/configurations.md
@@ -177,7 +177,7 @@ Five keys govern how a request's permissions are resolved:
 
 | Key | Default | Description |
 |---|---|---|
-| `authorization.enabled` | `true` | Master switch for Management API (`/api/v0.9`) authorization. With `false`, any authenticated caller satisfies every operation's scope list—a development opt-out that logs a startup warning |
+| `authorization.enabled` | `true` | Master switch for Management API (`/api-portal/api/v0.9`) authorization. With `false`, any authenticated caller satisfies every operation's scope list—a development opt-out that logs a startup warning |
 | `authorization.mode` | `role` | How a request's effective scopes are derived. `role` expands the token's roles claim through the mapping table and ignores the scope claim entirely, so a caller can't widen a role's grant by asking for extra scopes. `scope` reads the token's own scope claim—use it when the issuer mints `dp:*` scopes directly. Validated even when `enabled = false`, so a typo surfaces immediately |
 | `authorization.role_to_scope_mapping` | `./resources/role-to-scope-mapping.yaml` | Path to the YAML grant table. Required when `mode = "role"`. Validated at startup against the portal's OpenAPI spec whenever it's set—an undeclared `dp:*` scope fails startup rather than surfacing later as a role that logs in and is denied every request |
 | `authorization.page_role_validation` | `false` | Per-page role-tier gating. Separate from `enabled`, which governs REST scopes—one switch for both would mean turning page gating off also silently disabled REST enforcement |
@@ -209,7 +209,7 @@ Patterns are glob-matched (minimatch) against the request URL and merged with—
 
 ```toml
 [api_portal.organization]
-handle = "default"                       # URL slug: /{handle}/views/{viewName}
+handle = "default"                       # URL slug: /api-portal/{handle}/views/{viewName}
 display_name = "Default"                 # Used only when first seeding the organization
 auto_create_subscription_plans = true    # Auto-create Bronze/Silver/Gold/Unlimited/AsyncUnlimited
 ```

--- a/en/docs/next/api-portal/references/configurations.md
+++ b/en/docs/next/api-portal/references/configurations.md
@@ -111,11 +111,6 @@ pool_request_timeout_ms = 30000         # MSSQL only — per-query execution tim
 [api_portal.security]
 encryption_key = ""     # 64-char hex — AES-256-GCM key for encrypting secrets at rest
 session_secret = ""     # 64-char hex — express-session signing secret
-
-[api_portal.security.service_api_key]
-enabled = true
-header_name = "x-wso2-api-key"
-value = ""
 ```
 
 `encryption_key` and `session_secret` are required—the portal fails closed at startup if either doesn't resolve to a 64-character hex string. Generate one with `openssl rand -hex 32`.
@@ -136,22 +131,25 @@ platform_api_url = ""
 public_key_path = ""    # path to the Platform API's RS256 public key PEM
 tls_skip_verify = false
 
+# The [api_portal.auth.idp] endpoints describe your own identity provider and have
+# no default. issuer, authorization_url, token_url, client_id, and callback_url are
+# required when mode = "idp"; the portal refuses to start without them.
 [api_portal.auth.idp]
-name = "IS"
-issuer = "https://localhost:9443/oauth2/token"
-authorization_url = "https://localhost:9443/oauth2/authorize"
-token_url = "https://localhost:9443/oauth2/token"
-user_info_url = "https://localhost:9443/oauth2/userinfo"
+name = "my-idp"        # friendly name, used in logs
+issuer = ""
+authorization_url = ""
+token_url = ""
+user_info_url = ""
 client_id = ""
 client_secret = ""
 audience = ""
-callback_url = "http://localhost:9543/default/callback"
+callback_url = ""
 scope = "openid profile email"
 sign_up_url = ""
-logout_url = "https://localhost:9443/oidc/logout"
-logout_redirect_uri = "http://localhost:9543/default"
+logout_url = ""
+logout_redirect_uri = ""
 certificate = ""
-jwks_url = "https://localhost:9443/oauth2/jwks"
+jwks_url = ""
 token_refresh_timeout_ms = 10000
 silent_sso = true      # Enable silent SSO
 org_callback = false   # Redirect to the org's own landing page after login

--- a/en/docs/next/api-portal/references/get-a-bearer-token-via-curl.md
+++ b/en/docs/next/api-portal/references/get-a-bearer-token-via-curl.md
@@ -15,7 +15,7 @@ content_type: "how-to"
 
 # Getting a bearer token via curl (IDP mode)
 
-When the API Portal & MCP Hub is configured with an external IDP (e.g. Asgardeo), REST API calls to `/api/v0.9/*` must include an `Authorization: Bearer <token>` header. This guide obtains that token from the terminal, without going through the portal UI. One step still opens a browser: the identity provider's own login and redirect.
+When the API Portal & MCP Hub is configured with an external IDP (e.g. Asgardeo), REST API calls to `/api-portal/api/v0.9/*` must include an `Authorization: Bearer <token>` header. This guide obtains that token from the terminal, without going through the portal UI. One step still opens a browser: the identity provider's own login and redirect.
 
 !!! note
     If you're running in **local auth mode** instead (the default for local development), get a token from the Platform API directly—see [Getting Started](../getting-started.md)—no PKCE flow needed.
@@ -119,7 +119,7 @@ echo "TOKEN=$TOKEN"
 ```bash
 # The org is resolved from the token's org claim (set via ORGANIZATION_IDENTIFIER
 # during login in Step 3) — no org identifier needed in the request itself.
-BASE="https://localhost:9543/api/v0.9"
+BASE="https://localhost:9543/api-portal/api/v0.9"
 
 curl -sk "${BASE}/apis" -H "Authorization: Bearer $TOKEN" | jq .
 curl -sk "${BASE}/applications" -H "Authorization: Bearer $TOKEN" | jq .

--- a/en/docs/next/api-portal/references/get-a-bearer-token-via-curl.md
+++ b/en/docs/next/api-portal/references/get-a-bearer-token-via-curl.md
@@ -1,6 +1,6 @@
 ---
-title: "Get a Bearer token via curl (IDP mode)"
-description: "Obtain a Bearer token for the API Portal REST API from the terminal, without a browser, when running in external IDP mode."
+title: "Get a Bearer token via curl (IdP mode)"
+description: "Obtain a Bearer token for the API Portal REST API from the terminal, without a browser, when running in external IdP mode."
 canonical_url: https://wso2.com/api-platform/docs/cloud/api-portal/references/get-a-bearer-token-via-curl/
 md_url: https://wso2.com/api-platform/docs/cloud/api-portal/references/get-a-bearer-token-via-curl.md
 tags:
@@ -13,18 +13,18 @@ last_updated: 2026-07-24
 content_type: "how-to"
 ---
 
-# Getting a bearer token via curl (IDP mode)
+# Getting a bearer token via curl (IdP mode)
 
-When the API Portal & MCP Hub is configured with an external IDP (e.g. Asgardeo), REST API calls to `/api-portal/api/v0.9/*` must include an `Authorization: Bearer <token>` header. This guide obtains that token from the terminal, without going through the portal UI. One step still opens a browser: the identity provider's own login and redirect.
+When the API Portal & MCP Hub is configured with an external identity provider (IdP) such as Asgardeo, REST API calls to `/api-portal/api/v0.9/*` must include an `Authorization: Bearer <token>` header. This guide obtains that token from the terminal, without going through the portal UI. One step still opens a browser: the IdP's own login and redirect.
 
 !!! note
     If you're running in **local auth mode** instead (the default for local development), get a token from the Platform API directly—see [Getting Started](../getting-started.md)—no PKCE flow needed.
 
 ## Prerequisites
 
-- An identity provider (IDP) is configured, with `api_portal.auth.idp.client_id` set in `config.toml`—see [Authentication](../setting-up/authentication/overview.md)
+- An IdP is configured, with `api_portal.auth.idp.client_id` set in `config.toml`—see [Authentication](../setting-up/authentication/overview.md)
 - Your user carries the privileges the operations need: a role the portal's grant table names when `auth.authorization.mode = "role"`, or the `dp:*` scopes themselves when it's `"scope"`—see [Choose how privileges reach the token](../setting-up/authentication/connect-an-identity-provider.md#step-3-choose-how-privileges-reach-the-token)
-- You have the **client ID** and **client secret** from your IDP application
+- You have the **client ID** and **client secret** from your IdP application
 - You know your org's identifier (the `ORGANIZATION_IDENTIFIER` value used to scope the login, e.g. `sub`)
 
 ## Flow: Authorization code + Proof Key for Code Exchange (PKCE)
@@ -50,7 +50,7 @@ echo "CODE_CHALLENGE=$CODE_CHALLENGE"
 
 ## Step 2—start a local redirect listener
 
-The IDP redirects back to a callback URI with the authorization code. Use `nc` to capture it:
+The IdP redirects back to a callback URI with the authorization code. Use `nc` to capture it:
 
 ```bash
 PORT=8080
@@ -59,7 +59,7 @@ NC_PID=$!
 ```
 
 !!! note
-    Register `http://localhost:8080` as an authorized redirect URI in your IDP application before proceeding.
+    Register `http://localhost:8080` as an authorized redirect URI in your IdP application before proceeding.
 
 ## Step 3—build the authorization URL and open it
 
@@ -138,10 +138,10 @@ See the [Management API](../rest-api/overview.md) for the full set of available 
 |---|---|---|
 | `403 Missing organization claim in token` | Token has no org claim | Log in with `org=<ORGANIZATION_IDENTIFIER>` in the auth URL |
 | `403 Forbidden` (organization) | Token's org claim doesn't resolve to the organization this portal serves. Unknown and foreign organizations return the same status, so the response can't be used to discover which organizations exist | Verify `ORGANIZATION_IDENTIFIER` matches the portal's `[api_portal.organization] handle` |
-| `403 Forbidden` (scope error) | The request's effective scopes don't cover the operation | In `mode = "role"`, assign the user a role the portal's grant table names. In `mode = "scope"`, grant the operation's `dp:*` scope to the application in the IDP |
+| `403 Forbidden` (scope error) | The request's effective scopes don't cover the operation | In `mode = "role"`, assign the user a role the portal's grant table names. In `mode = "scope"`, grant the operation's `dp:*` scope to the application in the IdP |
 | `401 Authentication required` | Token expired or invalid | Re-run steps 1–5 for a fresh token |
 | Token carries no `dp:*` scopes | Expected in `mode = "role"`—the portal derives scopes from the roles claim and ignores the token's own scope claim, so an absent `dp:*` scope isn't the fault | Check the roles claim instead. In the Asgardeo console, assign `dp_admin` for full access, or `dp_subscriber`. Only `mode = "scope"` requires the scopes in the token |
-| `nc` gets no output | Redirect URI not registered in IDP | Add `http://localhost:8080` to authorized redirect URIs |
+| `nc` gets no output | Redirect URI not registered in IdP | Add `http://localhost:8080` to authorized redirect URIs |
 
 ## Token lifetime
 

--- a/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
+++ b/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
@@ -39,7 +39,7 @@ Check your IdP against these requirements before you start:
 | OIDC endpoints | Exposes authorization, token, userinfo, JWKS, and end-session endpoints. You supply each URL individually. |
 | Confidential client | Issues a client secret, and accepts PKCE on the authorization code exchange. |
 | Authorization code and refresh token grants | Both enabled on the application. The portal refreshes an expired access token before failing a Management API request. |
-| JWT access tokens | Access tokens are signed JWTs. The portal verifies a Bearer token's signature against the JWKS endpoint, so opaque tokens don't work for machine clients calling `/api-portal/api/v0.9`. |
+| JSON Web Token (JWT) access tokens | Access tokens are signed JWTs. The portal verifies a Bearer token's signature against the JWKS endpoint, so opaque tokens don't work for machine clients calling `/api-portal/api/v0.9`. |
 | Custom claims | Emits the organization identifier and the user's roles in the ID token. Claim names are configurable; the claims themselves are required. |
 
 ## Step 1: Register the portal as a confidential client

--- a/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
+++ b/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
@@ -39,15 +39,15 @@ Check your IdP against these requirements before you start:
 | OIDC endpoints | Exposes authorization, token, userinfo, JWKS, and end-session endpoints. You supply each URL individually. |
 | Confidential client | Issues a client secret, and accepts PKCE on the authorization code exchange. |
 | Authorization code and refresh token grants | Both enabled on the application. The portal refreshes an expired access token before failing a Management API request. |
-| JWT access tokens | Access tokens are signed JWTs. The portal verifies a Bearer token's signature against the JWKS endpoint, so opaque tokens don't work for machine clients calling `/api/v0.9`. |
+| JWT access tokens | Access tokens are signed JWTs. The portal verifies a Bearer token's signature against the JWKS endpoint, so opaque tokens don't work for machine clients calling `/api-portal/api/v0.9`. |
 | Custom claims | Emits the organization identifier and the user's roles in the ID token. Claim names are configurable; the claims themselves are required. |
 
 ## Step 1: Register the portal as a confidential client
 
 In your IdP, create a confidential OIDC application. Replace `<your-domain>` with the address users reach the portal at, including the port when it isn't 443, and `<org-handle>` with the value of `[api_portal.organization] handle`—`default` in the packaged configuration.
 
-1. Set the authorized redirect URL to `https://<your-domain>/<org-handle>/callback`.
-2. Set the post-logout redirect URL to `https://<your-domain>/<org-handle>`. Most IdPs validate `post_logout_redirect_uri` against the same list as the login callback, so add both URLs there.
+1. Set the authorized redirect URL to `https://<your-domain>/api-portal/<org-handle>/callback`.
+2. Set the post-logout redirect URL to `https://<your-domain>/api-portal/<org-handle>`. Most IdPs validate `post_logout_redirect_uri` against the same list as the login callback, so add both URLs there.
 3. Enable the **Authorization Code** and **Refresh Token** grants.
 4. Set the access token type to **JWT**.
 5. Configure the IdP to emit `given_name`, `family_name`, `email`, `roles`, and the claim carrying the organization identifier **in the ID token**. The portal reads user and organization identity from the ID token, not the access token, so a claim released only on the access token or the userinfo endpoint won't be seen.
@@ -73,7 +73,7 @@ The portal also reads these fixed claims, whose names aren't configurable: `sub`
 
 ## Step 3: Choose how privileges reach the token
 
-The portal's Management API (`/api/v0.9`) guards each operation with a `dp:*` scope. `[api_portal.auth.authorization] mode` decides where a request's effective scopes come from. Pick the one that matches what your IdP can put in a token.
+The portal's Management API (`/api-portal/api/v0.9`) guards each operation with a `dp:*` scope. `[api_portal.auth.authorization] mode` decides where a request's effective scopes come from. Pick the one that matches what your IdP can put in a token.
 
 **Role mode** (`mode = "role"`, the default) expands the token's roles claim through a YAML grant table and ignores the token's own scope claim entirely. Your IdP only has to emit role names, which most products do out of the box, and a caller can't widen a role's grant by requesting extra scopes. Set `role_to_scope_mapping` to the path of the table; the image ships an editable copy, which `docker-compose.yaml` mounts at `/etc/api-portal/role-to-scope-mapping.yaml`. It defines two roles:
 
@@ -123,9 +123,9 @@ jwks_url            = "https://idp.example.com/oauth2/jwks"
 client_id           = "<portal-client-id>"
 client_secret       = '{{ env "APIP_AP_AUTH_IDP_CLIENT_SECRET" }}'
 audience            = "<portal-client-id>"                              # expected "aud" claim
-callback_url        = "https://<your-domain>/<org-handle>/callback"
+callback_url        = "https://<your-domain>/api-portal/<org-handle>/callback"
 logout_url          = "https://idp.example.com/oidc/logout"
-logout_redirect_uri = "https://<your-domain>/<org-handle>"
+logout_redirect_uri = "https://<your-domain>/api-portal/<org-handle>"
 scope               = "openid profile email roles"
 
 # Which token claim carries each field. A sibling of [api_portal.auth.idp], not
@@ -198,7 +198,7 @@ organization = "org_name"
 
 This is the option to prefer when it's available to you. The claim keeps carrying a real organization identity, so a token minted for a different organization still resolves elsewhere and is still refused. It also keeps the authorization request correct: the portal appends `org=<handle>` to it, and a provider with a sub-organization model reads that parameter to scope the login session to the matching sub-organization.
 
-The handle is the URL slug in `/{handle}/views/{viewName}`, so it becomes part of every portal URL. Choose it with that in mind—and note that the portal normalizes it to lowercase, though claim matching tolerates any case.
+The handle is the URL slug in `/api-portal/{handle}/views/{viewName}`, so it becomes part of every portal URL. Choose it with that in mind—and note that the portal normalizes it to lowercase, though claim matching tolerates any case.
 
 ### When your IdP has no organization concept
 
@@ -233,7 +233,7 @@ If sign-in fails, the mismatch is usually one of these:
 - `issuer` doesn't match the token's `iss` claim, or `audience` doesn't match its `aud` claim.
 - The ID token doesn't carry the claim names configured in `[api_portal.auth.claim_mappings]`, so the organization or roles claim is never found.
 - The organization claim's value is neither the organization handle nor its display name, so it resolves to no organization the instance serves.
-- The IdP issues opaque access tokens rather than JWTs, which fails Bearer-token requests to `/api/v0.9` while browser login still works.
+- The IdP issues opaque access tokens rather than JWTs, which fails Bearer-token requests to `/api-portal/api/v0.9` while browser login still works.
 
 Set `[api_portal.logging] level = "debug"` to see which claim or check fails.
 

--- a/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
+++ b/en/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
@@ -1,8 +1,8 @@
 ---
 title: "Connect an identity provider to the API Portal"
 description: "Configure the API Portal & MCP Hub to delegate login to any OIDC identity provider: client registration, claim mappings, role or scope authorization, and the config.toml tables involved."
-canonical_url: https://wso2.com/api-platform/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider/
-md_url: https://wso2.com/api-platform/docs/next/api-portal/setting-up/authentication/connect-an-identity-provider.md
+canonical_url: https://wso2.com/api-platform/docs/cloud/api-portal/setting-up/authentication/connect-an-identity-provider/
+md_url: https://wso2.com/api-platform/docs/cloud/api-portal/setting-up/authentication/connect-an-identity-provider.md
 tags:
   - cloud
   - api-portal

--- a/en/docs/next/api-portal/setting-up/design-mode.md
+++ b/en/docs/next/api-portal/setting-up/design-mode.md
@@ -50,7 +50,7 @@ Then start the portal normally:
 npm start
 ```
 
-Visit `http://localhost:9543/views/default`.
+Visit `http://localhost:9543/api-portal/views/default`.
 
 !!! note
     The portal always starts on plain HTTP in design mode—no TLS certificate setup required.

--- a/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
+++ b/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
@@ -42,8 +42,8 @@ The API Portal & MCP Hub is a server-side application that can hold a client sec
 1. In the root organization, go to **Applications > New Application**.
 2. Choose **Traditional Web Application** and name it `API Portal & MCP Hub`.
 3. Under **Authorized redirect URLs**, add both, replacing `<org-handle>` with the sub-organization handle you settle on in step 5:
-      - `https://<your-domain>/<org-handle>/callback`—the login callback
-      - `https://<your-domain>/<org-handle>`—the post-logout redirect (Asgardeo validates `post_logout_redirect_uri` against this same list)
+      - `https://<your-domain>/api-portal/<org-handle>/callback`—the login callback
+      - `https://<your-domain>/api-portal/<org-handle>`—the post-logout redirect (Asgardeo validates `post_logout_redirect_uri` against this same list)
 
     This single shared URI pair is the only one you register. It matches the `callback_url` and `logout_redirect_uri` you set in step 4—after the callback, the portal uses the session's stored return path to route the user to the correct organization, so no per-organization redirect URLs are needed.
 4. Enable **Share with all organizations** so users in sub-organizations can log in.
@@ -91,9 +91,9 @@ jwks_url          = "https://api.asgardeo.io/t/<your-tenant>/oauth2/jwks"
 client_id         = "<api-portal-app-client-id>"
 client_secret     = '{{ env "APIP_AP_AUTH_IDP_CLIENT_SECRET" }}'
 audience          = "<api-portal-app-client-id>"   # Asgardeo sets the client ID as the aud claim
-callback_url      = "https://<your-domain>/<org-handle>/callback"
+callback_url      = "https://<your-domain>/api-portal/<org-handle>/callback"
 logout_url        = "https://api.asgardeo.io/t/<your-tenant>/oidc/logout"
-logout_redirect_uri = "https://<your-domain>/<org-handle>"
+logout_redirect_uri = "https://<your-domain>/api-portal/<org-handle>"
 scope             = "openid profile email roles"
 
 # Which token claim carries each field. Asgardeo B2B puts the sub-org handle in org_name.
@@ -141,7 +141,7 @@ display_name = "Acme"
 
 Set this before the portal first starts. The handle is what the portal writes into the organization's **IDP reference ID** when it seeds the organization row, and that field is fixed afterward—the Management API rejects a request that changes it. Changing the handle later means seeding a new organization.
 
-The handle is also the URL slug in `/{handle}/views/{viewName}`, so it appears in every portal URL. The portal normalizes it to lowercase, though the claim match itself tolerates any case.
+The handle is also the URL slug in `/api-portal/{handle}/views/{viewName}`, so it appears in every portal URL. The portal normalizes it to lowercase, though the claim match itself tolerates any case.
 
 With the two aligned, the login flow closes:
 
@@ -208,7 +208,7 @@ Keep the claim names consistent between the Asgardeo token attributes and the `[
 
 The script registers an API resource representing the portal, with all `dp:*` scopes under it. For local testing, its default `ASGARDEO_RESOURCE_IDENTIFIER=https://localhost:9543` works unchanged. The system application is only needed to run the script, and can be deleted afterward.
 
-In scope mode, browser sessions are preauthorized: the portal skips the per-operation scope check for a user signed in through Asgardeo, and page role gating is the authorization that applies to them. The `dp:*` scopes then govern machine clients calling `/api/v0.9` with a Bearer token.
+In scope mode, browser sessions are preauthorized: the portal skips the per-operation scope check for a user signed in through Asgardeo, and page role gating is the authorization that applies to them. The `dp:*` scopes then govern machine clients calling `/api-portal/api/v0.9` with a Bearer token.
 
 ## Related topics
 

--- a/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
+++ b/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
@@ -1,8 +1,8 @@
 ---
 title: "Set up Asgardeo as your identity provider"
 description: "Configure WSO2 Asgardeo as the OIDC identity provider for a production API Portal deployment, from application registration to config.toml."
-canonical_url: https://wso2.com/api-platform/docs/next/api-portal/tutorials/asgardeo-as-idp/
-md_url: https://wso2.com/api-platform/docs/next/api-portal/tutorials/asgardeo-as-idp.md
+canonical_url: https://wso2.com/api-platform/docs/cloud/api-portal/tutorials/asgardeo-as-idp/
+md_url: https://wso2.com/api-platform/docs/cloud/api-portal/tutorials/asgardeo-as-idp.md
 tags:
   - cloud
   - api-portal

--- a/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
+++ b/en/docs/next/api-portal/tutorials/asgardeo-as-idp.md
@@ -208,7 +208,7 @@ Keep the claim names consistent between the Asgardeo token attributes and the `[
 
 The script registers an API resource representing the portal, with all `dp:*` scopes under it. For local testing, its default `ASGARDEO_RESOURCE_IDENTIFIER=https://localhost:9543` works unchanged. The system application is only needed to run the script, and can be deleted afterward.
 
-In scope mode, browser sessions are preauthorized: the portal skips the per-operation scope check for a user signed in through Asgardeo, and page role gating is the authorization that applies to them. The `dp:*` scopes then govern machine clients calling `/api-portal/api/v0.9` with a Bearer token.
+In scope mode, browser sessions are preauthorized. For a user signed in through Asgardeo, the portal skips the per-operation scope check. Page role gating is the authorization that applies to them instead. The `dp:*` scopes then govern machine clients that call `/api-portal/api/v0.9` with a Bearer token.
 
 ## Related topics
 

--- a/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
+++ b/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
@@ -40,8 +40,8 @@ API Portal  ──signed webhook──▶  Platform API  ──control plane─�
 The API Portal distribution ships the Platform API alongside it, so one compose file gives you both.
 
 ```bash
-curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc2/wso2apip-api-portal-1.0.0-rc2.zip
-unzip wso2apip-api-portal-1.0.0-rc2.zip
+curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc3/wso2apip-api-portal-1.0.0-rc3.zip
+unzip wso2apip-api-portal-1.0.0-rc3.zip
 cd wso2apip-api-portal-1.0.0
 ./scripts/setup.sh
 docker compose up -d
@@ -93,7 +93,7 @@ Download the gateway distribution and run its setup:
 cd ..
 curl -sLO https://github.com/wso2/api-platform/releases/download/gateway%2Fv1.2.0-rc/wso2apip-api-gateway-1.2.0-rc.zip
 unzip wso2apip-api-gateway-1.2.0-rc.zip
-cd wso2apip-api-gateway-1.2.0
+cd wso2apip-api-gateway-1.2.0-rc
 ./scripts/setup.sh
 ```
 

--- a/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
+++ b/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
@@ -53,7 +53,7 @@ Confirm both are up:
 
 ```bash
 curl -fsk https://localhost:9243/health && echo " platform-api ok"
-curl -fsk -o /dev/null https://localhost:9543/default/views/default && echo "api-portal ok"
+curl -fsk -o /dev/null https://localhost:9543/api-portal/default/views/default && echo "api-portal ok"
 ```
 
 Now get a Platform API token and create a project to hold the API. Every Platform API call below uses this token, and the portal accepts the same one—it verifies it against the shared public key.
@@ -123,7 +123,7 @@ This is the seam. Two things have to be true before a portal-issued credential c
 **First, link the portal's organization to the control plane.** The Platform API resolves each incoming event's organization by handle, read from `org.ref_id`, which comes from the portal organization's `cpRefId`:
 
 ```bash
-curl -sk -X PUT https://localhost:9543/api/v0.9/organizations/default \
+curl -sk -X PUT https://localhost:9543/api-portal/api/v0.9/organizations/default \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d '{"id":"default","displayName":"Default","cpRefId":"default"}'
 ```
@@ -133,7 +133,7 @@ curl -sk -X PUT https://localhost:9543/api/v0.9/organizations/default \
 ```bash
 export WEBHOOK_SECRET=$(openssl rand -hex 32)
 
-curl -sk -X POST https://localhost:9543/api/v0.9/webhook-subscribers \
+curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/webhook-subscribers \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d "{\"id\":\"platform-api\",\"displayName\":\"Platform API\",
        \"targetUrl\":\"https://platform-api:9243/api/portal/v0.9/webhooks/events\",
@@ -218,7 +218,7 @@ The Platform API resolves each event's API and plan by **handle**, so the portal
 Sync the plan:
 
 ```bash
-curl -sk -X PUT https://localhost:9543/api/v0.9/subscription-plans \
+curl -sk -X PUT https://localhost:9543/api-portal/api/v0.9/subscription-plans \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d "[{\"id\":\"$PLAN\",\"displayName\":\"$PLAN\",\"refId\":\"$PLAN\",
         \"limits\":[{\"limitType\":\"REQUEST_COUNT\",\"limitCount\":10000,
@@ -228,13 +228,13 @@ curl -sk -X PUT https://localhost:9543/api/v0.9/subscription-plans \
 Then publish the API to the portal with `referenceId` set to the Platform API handle, and its specification attached. Write `api.yaml` and `definition.yaml` as shown in [Getting Started](../getting-started.md#step-6-publish-your-first-api), setting `referenceId` to the value of `$API_ID` and listing `$PLAN` under `subscriptionPlans`, then:
 
 ```bash
-curl -sk -X POST https://localhost:9543/api/v0.9/apis \
+curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/apis \
   -H "Authorization: Bearer $TOKEN" \
   -F "metadata=@api.yaml;type=application/yaml" \
   -F "definition=@definition.yaml;type=application/yaml"
 ```
 
-Open `https://localhost:9543/default/views/default/apis` and the API is in the catalog with its plan showing.
+Open `https://localhost:9543/api-portal/default/views/default/apis` and the API is in the catalog with its plan showing.
 
 ## Step 6: Get both credentials in the portal
 

--- a/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
+++ b/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
@@ -234,7 +234,7 @@ curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/apis \
   -F "definition=@definition.yaml;type=application/yaml"
 ```
 
-Open `https://localhost:9543/api-portal/default/views/default/apis` and the API is in the catalog with its plan showing.
+Open `https://localhost:9543/api-portal/default/views/default/apis`. The API appears in the catalog with its plan.
 
 ## Step 6: Get both credentials in the portal
 


### PR DESCRIPTION
## Purpose
$subject
Updating docs for RC3

## Checklist
 - [x] Verified that `llms.txt` (located at `en/docs/llms.txt`) is updated for AI readiness content. 
 - [x] Ensured meaningful alt text for images and that the information contained in an image also appears in text so the relevant info exists in the body of the document.
 - [x] Added or updated frontmatter for the respective pages.


## Approach

- Updated the API sample used in quick start guide to avoid handle collision
- Added "/api-portal/" prefix to base paths