### PR TITLE
Add doc frontmatter and link validation skill

### DIFF
--- a/.claude/skills/wso2-doc-frontmatter/SKILL.md
+++ b/.claude/skills/wso2-doc-frontmatter/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: wso2-doc-frontmatter
+description: Adds, repairs, and validates YAML frontmatter on WSO2 API Platform documentation pages, and checks the same pages for broken links and mechanical style-guide violations. Use this when migrating docs into wso2/docs-api-platform, when a page is missing frontmatter or has a wrong canonical_url/md_url/content_type/description, when checking a docs PR before merge, or when asked things like "add frontmatter to these pages", "why is this page's canonical URL wrong", "check this PR for broken links", "validate the metadata on all versions", or "audit the migrated docs". Handles the repo's multi-version layout (product/1.0.0/, product/1.1.0/, product/next/), where the current release is published at a version-less URL. Also runs non-interactively as a CI gate, so keep output structured.
+---
+
+# WSO2 API Platform doc frontmatter and validation
+
+Most of the work in validating these docs is mechanical, and mechanical work belongs in a script. The scripts here handle everything with one correct answer; your job is the part that needs reading the page and making a judgement — `description`, `content_type`, and `title`.
+
+Do not hand-edit frontmatter field by field across many files. Run the scripts, then fill in only what they hand back to you.
+
+## Requirements
+
+Python 3.8+ and nothing else. The scripts parse frontmatter with a built-in
+parser for the flat YAML subset used here, so they run on a bare `python3` with
+no `pip install` — which matters on macOS, where Homebrew Python refuses
+`pip install` under PEP 668. PyYAML is used automatically when present;
+`fm_audit.py --selftest` proves the built-in parser agrees with it across every
+page in the repo.
+
+## The rules this enforces
+
+The authoritative frontmatter spec is `.claude/rules/doc-frontmatter-and-metadata.md` **in the target repo**, not in this skill. Read it at the start of every run — it changes. `references/conventions.md` here records the mechanics that rule leaves implicit — version-to-URL mapping, quoting style, field order. Read that too.
+
+If the repo rule and `references/conventions.md` disagree, the repo rule wins, and say so in your report.
+
+## Workflow
+
+### 1. Audit first, always
+
+```bash
+python3 scripts/fm_audit.py en/docs --json /tmp/fm.json
+```
+
+Read the output before changing anything. It reports per-code counts and detects the repo's versioned products automatically. Add `--files a.md b.md` to scope it to a PR's changed files, and `--gate` to make it exit non-zero on blocking issues.
+
+The `--policy` flag decides how the version segment maps to a URL. `latest-only` (default, recommended) publishes the current release at the version-less URL and keeps the segment for older versions and `next`. `strip-all` has every version claim the same version-less URL, and will report the resulting collisions. Never change the policy without saying so explicitly in your report; it rewrites URLs across hundreds of files.
+
+### 2. Let the script fix what's mechanical
+
+```bash
+python3 scripts/fm_fix.py en/docs --dry-run                 # inspect first
+python3 scripts/fm_fix.py en/docs --scaffold --apply \
+    --worklist /tmp/work.json
+```
+
+This derives `canonical_url` and `md_url` from the path, normalises `last_updated` (from `git log` when it's missing or malformed), maps out-of-enum `content_type` values, lowercases `tags`, sets the standard `author`, and — with `--scaffold` — adds a whole frontmatter block to pages that have none, taking `title` from the H1.
+
+The *script* never invents a `description` or `title` — but **you do, in step 3.** That split is the whole design: a regex guessing a description would produce something plausible and wrong that looks finished, so nobody revisits it. Reading the page and writing a real one is your job, and it is not optional. A page left with `description: "TODO"` is not done.
+
+### 3. Fill in the judgement calls
+
+`--worklist` writes the files still needing you, with the page's H1 and current values for context. For each one, **read the actual page** — headings and opening section at minimum — then decide:
+
+- **`description`** — 90 to 155 characters, hard limit 158. Say what the reader can do or learn on this specific page, naming the actual feature or task. Present tense. No "This page describes…", no marketing adjectives, and none of the qualitative words the style guide bans ("easy", "simple", "quick"). Match the voice of existing good examples in the repo rather than inventing one.
+  - When a description is merely too long, **rewrite it — never truncate it.** A sentence cut at 158 characters reads as broken.
+- **`content_type`** — exactly one of `how-to`, `tutorial`, `reference`, `concept`, `explanation`, `troubleshooting`, `faq`, `release-notes`, `changelog`, `quickstart`. Pick by what the page *is*: numbered task steps → `how-to`; end-to-end learning walkthrough → `tutorial`; parameter and field tables → `reference`; explains an idea without steps → `concept`; diagnosing failures → `troubleshooting`. Section landing pages that are mostly link lists are `concept` — this is the settled default for this repo, so apply it without asking. `overview` is not a valid value; `CT_ALIASES` in `fm_lib.py` maps it to the closest valid type.
+- **`title`** — sentence case, under 60 characters. Only the first word plus genuine proper nouns and acronyms are capitalised: "AI Gateway", "API Platform", "Developer Portal", "Gateway Controller" stay capitalised; "Analytics", "Configuration", "Policy" do not, unless part of a product name.
+
+Write your decisions as a JSON map and hand them back to the script — don't edit files by hand:
+
+```bash
+cat > /tmp/filled.json <<'EOF'
+{"cloud/api-platform-gateway/troubleshooting.md": {
+   "title": "Troubleshoot the Self-Hosted Gateway",
+   "description": "Diagnose and resolve connection, registration, startup, TLS, policy, and routing failures on the API Platform Self-Hosted Gateway.",
+   "content_type": "troubleshooting"}}
+EOF
+python3 scripts/fm_fix.py en/docs --fill /tmp/filled.json --apply
+```
+
+Batch these — one `filled.json` for all outstanding files, not one run per file.
+
+### 4. Write the broken-link fix plan to its own file
+
+Link breakage is a *separate deliverable* from frontmatter. Never fold it into the
+chat reply or into the frontmatter report — it is a work queue someone else will
+pick up, so it belongs in a file that can be committed, reviewed, and assigned.
+
+```bash
+python3 scripts/report_links.py en/docs --scope <scope> \
+    --out BROKEN-LINKS-<scope>.md --json BROKEN-LINKS-<scope>.json
+```
+
+Always pass `--scope` when working one version, product, or section, and name the
+output after that scope. A single repo-wide report goes stale immediately and nobody
+can tell which parts are theirs.
+
+The report classifies every finding by **cause**, because the causes have
+completely different fixes and completely different risk:
+
+| Tier | Cause | Fix |
+|---|---|---|
+| — | Contains a template variable | **Leave alone.** Out of scope pending the redirect decision |
+| 0 | Malformed link syntax | Exact rewrite. No judgement. Safe in bulk. |
+| 1 | Wrong relative depth | Exact rewrite. No judgement. Safe in bulk. |
+| 2 | Renamed or moved target | A file of that name exists elsewhere; proposed, with confidence |
+| 3 | Pre-migration domain | Needs the new equivalent page — human |
+| 4 | Missing anchor | Heading was reworded — human |
+| 5 | No target anywhere | Was it dropped, missed, or merged? — human |
+
+It ends with a **ready-to-paste prompt for an AI coding agent**, deliberately
+scoped to tiers 0 and 1 and the high-confidence half of tier 2. Do not widen that scope.
+
+Two rules the reporter enforces, and you must not work around:
+
+- **Never rewrite a link whose target contains a build-time variable** such as
+  `{{base_path}}`. It is not a path, so there is nothing to resolve and any fix is
+  invented. How these migrate depends on the redirect strategy, which is a separate
+  decision.
+- **Never propose a target in a different version.** If a page under one version
+  links to something missing, the replacement must live under that same version. A
+  cross-version link silently sends a reader to a different release.
+Tiers 3 to 5 need information that is not in the repo, and an agent asked to fix
+them produces confident links to the wrong pages — worse than a visibly broken
+link, because a plausible wrong link never gets re-checked.
+
+When you report back, give the tier counts and say plainly how many need a human. A
+raw total is alarming and useless on its own; "N have an exact fix, M need a
+decision" is what someone can act on.
+
+### 5. Re-audit, and verify against a real build
+
+```bash
+python3 scripts/fm_audit.py en/docs --gate
+python3 scripts/check_redirects.py en/mkdocs.yml en/docs --gate
+python3 scripts/check_links.py en/docs
+python3 scripts/check_style.py en/docs
+```
+
+Re-auditing is not optional: it's the only thing that proves the fix worked rather than moved the problem.
+
+Where the repo can be built, `mkdocs build` is the authoritative check on links — the link checker is calibrated against it and finds a superset of what it reports. If you have the dependencies, run it and reconcile any difference rather than assuming the script is right.
+
+## The other checkers
+
+`scripts/check_redirects.py` validates `redirect_maps` in `mkdocs.yml` — targets exist, no source shadowed by a real file, no chains (the plugin doesn't follow them), no map left pointing at a superseded version after a version bump.
+
+Its most valuable check is the one neither a redirect audit nor a frontmatter audit can do alone: **`CANONICAL_UNREACHABLE`**. Under `latest-only`, a current-release page's `canonical_url` is the version-less path — which is not a file, and resolves *only* because a redirect maps it onto the release. So a page can have perfectly valid frontmatter and a perfectly valid redirect map, and still declare a canonical URL that 404s. Each half looks correct in isolation; only the cross-check sees it. Always run this after changing the URL policy or adding a new page to a versioned tree.
+
+`scripts/check_links.py` resolves every relative link, image, and anchor against what's on disk, and flags links still pointing at a pre-migration location (the list is `LEGACY_DOMAINS` in `fm_lib.py`). It catches everything `mkdocs build` warns about plus two classes mkdocs stays silent on: bare directory links to a directory with no `index.md`/`README.md`, and directory links to a path that doesn't exist at all.
+
+Note what `check_links.py` does **not** do: it only resolves links whose target is inside the repo. It cannot tell you whether a page is reachable at its own published URL — that is `check_redirects.py`'s job. "No broken links" and "every canonical URL resolves" are two different claims, and passing the first says nothing about the second.
+
+`scripts/check_style.py` covers only the *mechanically decidable* part of the style guide — heading case, banned qualitative and time-bound words, en dashes, non-descriptive link text. It is not a replacement for reading the prose. Two things to know before you trust its output:
+
+- **Heading case depends on its allowlist.** `PROPER` and `PROPER_PHRASES` in the script hold the product names that legitimately stay capitalised, and essentially every false positive traces to a name the list doesn't know yet. When you hit one, **add the name to `PROPER_PHRASES` rather than suppressing the finding** — that is how the checker improves. Headings with exactly one unexpected capital are reported separately as `HEADING_CASE_SINGLE_WORD` at lower severity, because a lone capital is usually an unknown product name.
+- **Banned-word rules need your judgement on scope.** The style guide bans "new" and "latest" *"when describing product or feature capabilities."* "Generate a **new** token" is fine; "these **new** subcommands" is a violation. The script cannot tell these apart and will flag both. Read the surrounding sentence before reporting a `TIMELESS` or `QUALITATIVE` hit.
+
+Some findings are established house conventions rather than slips. When a single pattern recurs across hundreds of pages, report it **once** as a convention question rather than as hundreds of findings. The style guide says outright that it "contains guidelines, not draconian rules", and a checker that ignores that stops being used.
+
+## Reporting
+
+Lead with the counts and what you changed. Then group findings by code, not by file — a hundred identical `canonical_url` corrections are one line of report, not a hundred. Show one representative diff per group.
+
+Separate three things clearly, because they need different responses:
+
+1. **Fixed automatically** — what the scripts changed, by code and count.
+2. **Needs a human decision** — genuine ambiguity or repo-wide convention questions. State the options and your recommendation; don't silently pick one.
+3. **Still outstanding** — what neither the scripts nor you could resolve, and why.
+
+Never report a count without saying whether it counts occurrences or affected files. Those differ by an order of magnitude, and conflating them makes the report useless.
+
+When running in CI, end with a single machine-readable line so a build step can grep it:
+
+```
+<!-- wso2-doc-frontmatter: STATUS=FAIL files=<N> blocking=<N> should_fix=<N> -->
+```
+
+`STATUS=FAIL` only when there is at least one blocking issue. Because blocking counts drive a merge gate, do not inflate severity — a should-fix reported as blocking is how a gate loses its credibility.

--- a/.claude/skills/wso2-doc-frontmatter/SKILL.md
+++ b/.claude/skills/wso2-doc-frontmatter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wso2-doc-frontmatter
-description: Adds, repairs, and validates YAML frontmatter on WSO2 API Platform documentation pages, and checks the same pages for broken links and mechanical style-guide violations. Use this when migrating docs into wso2/docs-api-platform, when a page is missing frontmatter or has a wrong canonical_url/md_url/content_type/description, when checking a docs PR before merge, or when asked things like "add frontmatter to these pages", "why is this page's canonical URL wrong", "check this PR for broken links", "validate the metadata on all versions", or "audit the migrated docs". Handles the repo's multi-version layout (product/1.0.0/, product/1.1.0/, product/next/), where the current release is published at a version-less URL. Also runs non-interactively as a CI gate, so keep output structured.
+description: Adds, repairs, and validates YAML frontmatter on WSO2 API Platform documentation pages, and checks the same pages for broken links and mechanical style-guide violations. Use this when migrating docs into wso2/docs-api-platform, when a page is missing frontmatter or has a wrong canonical_url/md_url/content_type/description, when checking a docs PR before merge, or when asked things like "add frontmatter to these pages", "why is this page's canonical URL wrong", "check this PR for broken links", "validate the metadata on all versions", or "audit the migrated docs". Handles the repo's multi-version layout (product/1.0.0/, product/1.1.0/, product/next/), where every version is published at a URL that includes its version segment. Also runs non-interactively as a CI gate, so keep output structured.
 ---
 
 # WSO2 API Platform doc frontmatter and validation
@@ -34,7 +34,7 @@ python3 scripts/fm_audit.py en/docs --json /tmp/fm.json
 
 Read the output before changing anything. It reports per-code counts and detects the repo's versioned products automatically. Add `--files a.md b.md` to scope it to a PR's changed files, and `--gate` to make it exit non-zero on blocking issues.
 
-The `--policy` flag decides how the version segment maps to a URL. `latest-only` (default, recommended) publishes the current release at the version-less URL and keeps the segment for older versions and `next`. `strip-all` has every version claim the same version-less URL, and will report the resulting collisions. Never change the policy without saying so explicitly in your report; it rewrites URLs across hundreds of files.
+The `--policy` flag decides how the version segment maps to a URL. `keep-all` (the default) keeps it for every version, latest release included, which is what the site does. The other two do not match the site. Never change the policy without saying so explicitly in your report; it rewrites URLs across hundreds of files.
 
 ### 2. Let the script fix what's mechanical
 
@@ -91,7 +91,8 @@ completely different fixes and completely different risk:
 
 | Tier | Cause | Fix |
 |---|---|---|
-| — | Contains a template variable | **Leave alone.** Out of scope pending the redirect decision |
+| 0 | `{{base_path}}` and the resource exists | Exact rewrite to a relative path |
+| — | `{{base_path}}` and it does not | **Leave alone.** May be served by a redirect |
 | 0 | Malformed link syntax | Exact rewrite. No judgement. Safe in bulk. |
 | 1 | Wrong relative depth | Exact rewrite. No judgement. Safe in bulk. |
 | 2 | Renamed or moved target | A file of that name exists elsewhere; proposed, with confidence |
@@ -104,10 +105,9 @@ scoped to tiers 0 and 1 and the high-confidence half of tier 2. Do not widen tha
 
 Two rules the reporter enforces, and you must not work around:
 
-- **Never rewrite a link whose target contains a build-time variable** such as
-  `{{base_path}}`. It is not a path, so there is nothing to resolve and any fix is
-  invented. How these migrate depends on the redirect strategy, which is a separate
-  decision.
+- **`{{base_path}}` is version-root-relative.** Where the resource exists at that
+  path, convert the link to a relative path and drop the variable — that is an exact
+  fix. Where it does not exist, leave it: it may be served by a redirect.
 - **Never propose a target in a different version.** If a page under one version
   links to something missing, the replacement must live under that same version. A
   cross-version link silently sends a reader to a different release.
@@ -136,7 +136,7 @@ Where the repo can be built, `mkdocs build` is the authoritative check on links 
 
 `scripts/check_redirects.py` validates `redirect_maps` in `mkdocs.yml` — targets exist, no source shadowed by a real file, no chains (the plugin doesn't follow them), no map left pointing at a superseded version after a version bump.
 
-Its most valuable check is the one neither a redirect audit nor a frontmatter audit can do alone: **`CANONICAL_UNREACHABLE`**. Under `latest-only`, a current-release page's `canonical_url` is the version-less path — which is not a file, and resolves *only* because a redirect maps it onto the release. So a page can have perfectly valid frontmatter and a perfectly valid redirect map, and still declare a canonical URL that 404s. Each half looks correct in isolation; only the cross-check sees it. Always run this after changing the URL policy or adding a new page to a versioned tree.
+`CANONICAL_UNREACHABLE` only fires under `--policy latest-only`. Under the default `keep-all` a canonical is a versioned path, so it cannot depend on a redirect existing.
 
 `scripts/check_links.py` resolves every relative link, image, and anchor against what's on disk, and flags links still pointing at a pre-migration location (the list is `LEGACY_DOMAINS` in `fm_lib.py`). It catches everything `mkdocs build` warns about plus two classes mkdocs stays silent on: bare directory links to a directory with no `index.md`/`README.md`, and directory links to a path that doesn't exist at all.
 

--- a/.claude/skills/wso2-doc-frontmatter/references/conventions.md
+++ b/.claude/skills/wso2-doc-frontmatter/references/conventions.md
@@ -1,0 +1,167 @@
+# Frontmatter conventions
+
+Reference for the conventions the scripts implement. The authoritative list of
+*required fields* is `.claude/rules/doc-frontmatter-and-metadata.md` in this
+repository; this file records the mechanics that rule leaves implicit — field
+order, quoting, and how a file path maps to a URL.
+
+If this file and the repository rule disagree, the rule wins.
+
+## Field order and quoting
+
+```yaml
+---
+title: "Moesif analytics"                        # double-quoted
+description: "Configure Moesif to capture ..."   # double-quoted
+canonical_url: https://wso2.com/...              # bare
+md_url: https://wso2.com/...                     # bare
+tags:                                            # block list, lowercase items
+  - ai-gateway
+  - analytics
+author: WSO2 API Platform Documentation Team     # bare
+last_updated: 2026-06-16                         # bare YYYY-MM-DD, never quoted
+content_type: "how-to"                           # double-quoted
+---
+```
+
+`fm_fix.py` reproduces this exactly, including the quoting. That matters for a
+practical reason: if the serialiser quotes differently from the house style, every
+page it touches shows a diff even where no value changed, and the real changes get
+buried.
+
+## URL derivation
+
+`BASE` is `https://wso2.com/api-platform/docs`.
+
+| Source file | `canonical_url` | `md_url` |
+|---|---|---|
+| `foo/bar.md` | `{BASE}/foo/bar/` | `{BASE}/foo/bar.md` |
+| `foo/index.md` | `{BASE}/foo/` | `{BASE}/foo.md` |
+| `foo/README.md` | `{BASE}/foo/` | `{BASE}/foo.md` |
+
+`README.md` collapses to its directory the same way `index.md` does.
+
+## Versions
+
+Some products keep several versions on disk:
+
+```
+<product>/1.0.0/...
+<product>/1.1.0/...
+<product>/next/...
+```
+
+The published site serves the **current release at a version-less URL**, with the
+`redirects` plugin in `mkdocs.yml` mapping that version-less path onto the current
+release's file. Every other version — older releases, and `next` — is served at a
+URL that includes its version segment.
+
+So the rule the scripts implement, which `fm_lib.py:site_paths()` calls
+`latest-only`:
+
+> The current release gets the version-less URL. Every other version keeps its
+> version segment in both `canonical_url` and `md_url`.
+
+This is the only policy under which each file owns a unique `md_url`. Two
+alternatives exist for comparison and are selectable with `--policy`:
+
+| Policy | Behaviour |
+|---|---|
+| `latest-only` | Default. Current release version-less, others keep their segment. |
+| `strip-all` | Every version claims the version-less URL. Produces collisions. |
+| `keep-all` | Every version keeps its segment. No stable "latest" URL. |
+
+Changing the policy rewrites URLs across every versioned page, so say so
+explicitly when you do.
+
+### A version segment is only a version at the top of the tree
+
+`discover_versions()` treats a directory as a documentation version only at the
+docs root (`next/...`) or directly under a single-segment product directory
+(`<product>/4.7.0/...`). Anything deeper that merely looks like a version is
+something else — most often a third-party connector's own release directory:
+
+```
+<product>/<version>/reference/connectors/<connector>/1.0.1/
+```
+
+Treating that as a documentation version would invent a phantom product and strip
+the wrong segment out of a URL, so the depth limit in `MAX_VERSION_DEPTH` is
+load-bearing rather than cosmetic.
+
+## Redirects and `canonical_url` are one contract
+
+Under `latest-only`, a current-release page's `canonical_url` is a version-less
+path. That path is not a file — it resolves only because a redirect maps it onto
+the release. A page can therefore have valid frontmatter *and* a valid redirect
+map and still declare a canonical URL that resolves to nothing, because each half
+looks correct on its own.
+
+`check_redirects.py` is what catches that, as `CANONICAL_UNREACHABLE`. Run it
+after changing the URL policy, and after adding a page to a versioned tree.
+
+The practical consequence: **adding a page to a versioned tree is a two-part
+change** — the page, and a `redirect_maps` entry for its version-less path. Miss
+the second and the page still renders and still passes a link check; only its
+declared canonical URL is dead.
+
+## Links containing build-time variables
+
+Pages migrated from the API Manager docs may contain link and image targets built
+around a template variable:
+
+```markdown
+[Rate limiting]({{base_path}}/api-design-manage/design/rate-limiting/overview/)
+<img src="{{base_path}}/assets/img/example.png" />
+```
+
+Both the Markdown and raw-HTML forms occur. The variable is substituted at build
+time by machinery that is not present in this site, which is why migrated pages use
+relative links instead.
+
+The checkers treat these as **out of scope, not broken**: `check_links.py` reports
+`LINK_TEMPLATED` at `polish` severity, and `report_links.py` quarantines them in a
+section with no proposed fix. Nothing should rewrite them until the redirect
+strategy is settled, because the right replacement depends on that decision.
+
+Redirects themselves belong either in a `redirects.yml` file or in a `redirects`
+block inside `mkdocs.yml`.
+
+## Adding another source of documentation
+
+Nothing in the scripts is tied to a particular product or version. Versions are
+discovered from the directory tree, and each product's current release is resolved
+independently, so a new product or a version bump needs no code change.
+
+Two things are configuration rather than logic, both in `fm_lib.py`:
+
+- **`LEGACY_DOMAINS`** — locations the documentation has migrated away from. A link
+  or frontmatter URL still pointing at one is migration debt. When another set of
+  docs is folded in, add its old domain here; the checkers pick it up.
+- **`CT_ALIASES`** — near-miss `content_type` values seen in incoming pages, mapped
+  onto the closest valid type. Extend it when a new source uses different names.
+
+## `content_type`
+
+One of `how-to`, `tutorial`, `reference`, `concept`, `explanation`,
+`troubleshooting`, `faq`, `release-notes`, `changelog`, `quickstart` — based on
+the Diátaxis framework.
+
+Choose by what the page *is*: numbered task steps → `how-to`; an end-to-end
+learning walkthrough → `tutorial`; parameter and field tables → `reference`;
+explains an idea without steps → `concept`; diagnosing failures →
+`troubleshooting`. A section landing page that is mostly a list of links is
+`concept`.
+
+`overview` is not a valid value. `CT_ALIASES` in `fm_lib.py` maps it, and a few
+other near-misses, onto the closest valid type.
+
+## Fields the scripts will not generate
+
+`title` and `description` are what a reader and a search engine actually see. A
+generated one looks finished, so nobody revisits it — which is worse than an
+obviously missing one.
+
+`fm_fix.py` derives `title` from an existing H1 when scaffolding, since that is an
+editorial decision someone already made, and leaves `description` as `TODO` in the
+worklist for a person or an LLM to write after reading the page.

--- a/.claude/skills/wso2-doc-frontmatter/references/conventions.md
+++ b/.claude/skills/wso2-doc-frontmatter/references/conventions.md
@@ -39,7 +39,9 @@ buried.
 | `foo/index.md` | `{BASE}/foo/` | `{BASE}/foo.md` |
 | `foo/README.md` | `{BASE}/foo/` | `{BASE}/foo.md` |
 
-`README.md` collapses to its directory the same way `index.md` does.
+`README.md` is handled the same way as `index.md`. Note that most `README.md` files
+under `en/docs/` are housekeeping notes rather than documentation pages, and none are
+currently in the mkdocs nav.
 
 ## Versions
 
@@ -51,28 +53,20 @@ Some products keep several versions on disk:
 <product>/next/...
 ```
 
-The published site serves the **current release at a version-less URL**, with the
-`redirects` plugin in `mkdocs.yml` mapping that version-less path onto the current
-release's file. Every other version — older releases, and `next` — is served at a
-URL that includes its version segment.
+**Every version, including the latest, is published at a URL that includes its
+version segment.** So `canonical_url` and `md_url` both keep it.
 
-So the rule the scripts implement, which `fm_lib.py:site_paths()` calls
-`latest-only`:
+A version-less URL redirects to the versioned page rather than serving content, so it
+is never the canonical.
 
-> The current release gets the version-less URL. Every other version keeps its
-> version segment in both `canonical_url` and `md_url`.
-
-This is the only policy under which each file owns a unique `md_url`. Two
-alternatives exist for comparison and are selectable with `--policy`:
+`fm_lib.py:site_paths()` calls this `keep-all`, and it is the default. Two other
+policies are selectable with `--policy`; neither matches the site:
 
 | Policy | Behaviour |
 |---|---|
-| `latest-only` | Default. Current release version-less, others keep their segment. |
-| `strip-all` | Every version claims the version-less URL. Produces collisions. |
-| `keep-all` | Every version keeps its segment. No stable "latest" URL. |
-
-Changing the policy rewrites URLs across every versioned page, so say so
-explicitly when you do.
+| `keep-all` | Default. Every version keeps its segment. |
+| `latest-only` | Latest release gets a version-less URL. |
+| `strip-all` | All versions share one version-less URL. Produces collisions. |
 
 ### A version segment is only a version at the top of the tree
 
@@ -89,21 +83,15 @@ Treating that as a documentation version would invent a phantom product and stri
 the wrong segment out of a URL, so the depth limit in `MAX_VERSION_DEPTH` is
 load-bearing rather than cosmetic.
 
-## Redirects and `canonical_url` are one contract
+## Redirects
 
-Under `latest-only`, a current-release page's `canonical_url` is a version-less
-path. That path is not a file — it resolves only because a redirect maps it onto
-the release. A page can therefore have valid frontmatter *and* a valid redirect
-map and still declare a canonical URL that resolves to nothing, because each half
-looks correct on its own.
+`check_redirects.py` validates `redirect_maps` in `mkdocs.yml`: every target exists,
+no source is shadowed by a real file, no chains (the plugin does not follow them),
+and no map is left pointing at a superseded version after a version bump.
 
-`check_redirects.py` is what catches that, as `CANONICAL_UNREACHABLE`. Run it
-after changing the URL policy, and after adding a page to a versioned tree.
-
-The practical consequence: **adding a page to a versioned tree is a two-part
-change** — the page, and a `redirect_maps` entry for its version-less path. Miss
-the second and the page still renders and still passes a link check; only its
-declared canonical URL is dead.
+`CANONICAL_UNREACHABLE` only applies under `--policy latest-only`. Under `keep-all` a
+canonical is a versioned path, which is a real file, so it cannot depend on a
+redirect existing.
 
 ## Links containing build-time variables
 
@@ -115,14 +103,17 @@ around a template variable:
 <img src="{{base_path}}/assets/img/example.png" />
 ```
 
-Both the Markdown and raw-HTML forms occur. The variable is substituted at build
-time by machinery that is not present in this site, which is why migrated pages use
-relative links instead.
+Both the Markdown and raw-HTML forms occur. The variable is not available in this
+site, so these links need converting to relative paths.
 
-The checkers treat these as **out of scope, not broken**: `check_links.py` reports
-`LINK_TEMPLATED` at `polish` severity, and `report_links.py` quarantines them in a
-section with no proposed fix. Nothing should rewrite them until the redirect
-strategy is settled, because the right replacement depends on that decision.
+`{{base_path}}` stands for the root of that version's site, so the rest of the target
+is a path within the version's directory. That makes most of them mechanically
+fixable, and `report_links.py` splits them accordingly:
+
+- **The resource exists at that path** — drop the variable and write an ordinary
+  relative path. The replacement is exact, and this is the large majority.
+- **It does not exist there** — leave the link alone. It may be served by a redirect,
+  or the page may not have been migrated. Rewriting it would be a guess.
 
 Redirects themselves belong either in a `redirects.yml` file or in a `redirects`
 block inside `mkdocs.yml`.

--- a/.claude/skills/wso2-doc-frontmatter/scripts/check_links.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/check_links.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Link + asset checker for wso2/docs-api-platform (migration-aware)."""
+import os, re, sys, json, collections, urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fm_lib import is_legacy_url  # noqa: E402
+
+import argparse
+_ap = argparse.ArgumentParser()
+_ap.add_argument("docs_root", nargs="?", default="en/docs")
+_ap.add_argument("--json", dest="json_out", default=None,
+                 help="Write full findings to this path. Omitted = summary only.")
+_ap.add_argument("--gate", action="store_true", help="Exit 1 if any blocking finding.")
+_args = _ap.parse_args()
+DOCS = _args.docs_root.rstrip("/")
+SITE = "https://wso2.com/api-platform/docs"
+VER = re.compile(r"^(\d+\.\d+(\.\d+)?|next|latest)$")
+
+md_files, all_files = set(), set()
+for root, _, fs in os.walk(DOCS):
+    for f in fs:
+        rel = os.path.relpath(os.path.join(root, f), DOCS)
+        all_files.add(rel)
+        if f.endswith(".md"):
+            md_files.add(rel)
+
+def slug(h):
+    """Match python-markdown's toc slugify: strip non-word chars, then collapse
+    runs of whitespace AND hyphens into a single hyphen."""
+    h = re.sub(r"`|\*", "", h)   # backticks/emphasis markers; keep _ (it is a \w char)
+    h = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", h)   # link text only
+    h = re.sub(r"<[^>]+>", "", h)
+    h = re.sub(r"[^\w\s-]", "", h).strip().lower()
+    return re.sub(r"[-\s]+", "-", h)
+
+# harvest anchors per file (headings + explicit <a name>/{#id})
+anchors = {}
+for p in md_files:
+    txt = open(os.path.join(DOCS, p), encoding="utf-8", errors="replace").read()
+    txt = re.sub(r"<!--.*?-->", "", txt, flags=re.S)
+    txt = re.sub(r"```.*?```", "", txt, flags=re.S)
+    a = set()
+    for m in re.finditer(r"^#{1,6}\s+(.+?)\s*$", txt, re.M):
+        h = m.group(1)
+        exp = re.search(r"\{#([\w-]+)\}", h)
+        if exp: a.add(exp.group(1)); h = h[:exp.start()]
+        a.add(slug(h))
+    for m in re.finditer(r'<a[^>]+(?:name|id)="([^"]+)"', txt): a.add(m.group(1))
+    for m in re.finditer(r'\{#([\w-]+)\}', txt): a.add(m.group(1))
+    anchors[p] = a
+
+LINK = re.compile(r'(!?)\[([^\]]*)\]\(\s*<?([^)\s>]+)>?(?:\s+"[^"]*")?\s*\)')
+HTML_SRC = re.compile(r'<img[^>]+src="([^"]+)"')
+
+findings = []
+def add(f, sev, code, msg):
+    findings.append({"file": f, "severity": sev, "code": code, "message": msg})
+
+for p in sorted(md_files):
+    full = os.path.join(DOCS, p)
+    txt = open(full, encoding="utf-8", errors="replace").read()
+    body = re.sub(r"<!--.*?-->", "", txt, flags=re.S)
+    body = re.sub(r"```.*?```", "", body, flags=re.S)
+    body = re.sub(r"`[^`\n]*`", "", body)
+    d = os.path.dirname(p)
+
+    targets = [(m.group(1) == "!", m.group(3)) for m in LINK.finditer(body)]
+    targets += [(True, m.group(1)) for m in HTML_SRC.finditer(body)]
+
+    for is_img, t in targets:
+        if t.startswith(("mailto:", "tel:", "#!")):
+            continue
+        # Build-time template variables (e.g. `{{base_path}}`) are not paths. They
+        # cannot be resolved statically and are not broken in their own context, so
+        # report them as informational rather than as broken links.
+        if re.search(r"\{\{.*?\}\}", t):
+            add(p, "polish", "LINK_TEMPLATED",
+                f"Target contains a build-time variable, so it can't be checked statically: `{t}`")
+            continue
+        # stale pre-migration domain
+        if is_legacy_url(t):
+            add(p, "blocking", "STALE_LINK", f"Links to the pre-migration site: `{t}`")
+            continue
+        if re.match(r"^https?://", t):
+            if t.startswith(SITE):
+                # absolute self-link — should be relative, and must resolve
+                add(p, "should-fix", "ABS_SELF_LINK",
+                    f"Absolute link to our own site: `{t}` — use a relative path so it survives moves and works in previews.")
+            continue
+        if t.startswith("//"):
+            continue
+        if t.startswith("#"):
+            frag = urllib.parse.unquote(t[1:])
+            if frag and frag not in anchors.get(p, set()):
+                add(p, "should-fix", "ANCHOR_MISSING", f"In-page anchor `{t}` has no matching heading.")
+            continue
+
+        path, _, frag = t.partition("#")
+        path = urllib.parse.unquote(path)
+        frag = urllib.parse.unquote(frag)
+        if not path:
+            continue
+        cand = os.path.normpath(os.path.join(d, path)) if not path.startswith("/") else path.lstrip("/")
+        if cand.startswith(".."):
+            add(p, "blocking", "LINK_ESCAPES_ROOT", f"Link `{t}` resolves outside the docs root.")
+            continue
+
+        resolved = None
+        for c in (cand, cand + ".md", os.path.join(cand, "index.md"), os.path.join(cand, "README.md")):
+            if c in all_files:
+                resolved = c; break
+        if resolved is None:
+            if os.path.isdir(os.path.join(DOCS, cand)):
+                add(p, "should-fix", "LINK_DIR_NO_INDEX", f"Link `{t}` points at a directory with no index.md/README.md.")
+            else:
+                code = "IMG_MISSING" if is_img else "LINK_BROKEN"
+                add(p, "blocking", code, f"{'Image' if is_img else 'Link'} target does not exist: `{t}`")
+            continue
+        if frag and resolved.endswith(".md"):
+            if frag not in anchors.get(resolved, set()):
+                add(p, "should-fix", "ANCHOR_MISSING",
+                    f"Anchor `#{frag}` not found in `{resolved}` (link was `{t}`).")
+
+    # Alt text. The style guide is specific here and it is easy to get wrong:
+    #   - alt="" is CORRECT for purely decorative images or screenshots that
+    #     merely mirror the text steps. Do not flag it as missing.
+    #   - informative images need meaningful alt text, max 155 characters.
+    #   - "Image of" / "Photo of" prefixes are called out to avoid.
+    for m in LINK.finditer(body):
+        if m.group(1) != "!":
+            continue
+        alt, src = m.group(2), m.group(3)
+        if not alt.strip():
+            add(p, "polish", "IMG_ALT_EMPTY_VERIFY",
+                f"Image has alt=\"\": `{src}`. Correct if the image is decorative or "
+                f"mirrors the text steps; a defect if it carries information.")
+        elif len(alt) > 155:
+            add(p, "should-fix", "IMG_ALT_TOO_LONG",
+                f"Alt text is {len(alt)} chars; the guide caps it at 155: `{src}`")
+        if re.match(r"^\s*(image|photo|picture|screenshot)\s+of\b", alt, re.I):
+            add(p, "should-fix", "IMG_ALT_PREFIX",
+                f"Alt text starts with \"{alt.split()[0]} of\" — the guide calls this out to avoid: `{src}`")
+        if re.search(r"\.gif$", src.split("#")[0], re.I):
+            add(p, "should-fix", "IMG_ANIMATED_GIF",
+                f"Animated GIF: `{src}`. The guide says use a resource-efficient format like MP4 instead.")
+
+# orphan assets
+used = set()
+for p in md_files:
+    txt = re.sub(r"<!--.*?-->", "", open(os.path.join(DOCS, p), encoding="utf-8", errors="replace").read(), flags=re.S)
+    d = os.path.dirname(p)
+    for m in list(LINK.finditer(txt)) + list(HTML_SRC.finditer(txt)):
+        t = m.group(3) if m.lastindex and m.lastindex >= 3 else m.group(1)
+        if re.match(r"^(https?:|mailto:|#)", t): continue
+        t = urllib.parse.unquote(t.split("#")[0])
+        if not t: continue
+        used.add(os.path.normpath(os.path.join(d, t)) if not t.startswith("/") else t.lstrip("/"))
+assets = {f for f in all_files if f.startswith("assets/") and re.search(r"\.(png|jpg|jpeg|gif|svg|webp|mp4)$", f, re.I)}
+orphans = sorted(assets - used)
+
+by = collections.Counter((f["code"], f["severity"]) for f in findings)
+print("=" * 68); print("LINK & ASSET CHECK"); print("=" * 68)
+print(f"md files scanned  : {len(md_files)}")
+print(f"total findings    : {len(findings)}")
+print(f"orphaned assets   : {len(orphans)} of {len(assets)} images never referenced")
+print()
+print(f"{'COUNT':>6}  {'SEV':<11} CODE"); print("-" * 68)
+for (code, sev), n in by.most_common():
+    print(f"{n:>6}  {sev:<11} {code}")
+if _args.json_out:
+    json.dump({"findings": findings, "orphans": orphans}, open(_args.json_out, "w"), indent=1)
+    print(f"\n(full findings -> {_args.json_out})")
+else:
+    print("\n(re-run with --json <path> for the full findings list)")
+
+if _args.gate and any(f["severity"] == "blocking" for f in findings):
+    sys.exit(1)

--- a/.claude/skills/wso2-doc-frontmatter/scripts/check_redirects.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/check_redirects.py
@@ -4,13 +4,13 @@
     python3 scripts/check_redirects.py en/mkdocs.yml en/docs
     python3 scripts/check_redirects.py en/mkdocs.yml en/docs --gate
 
-The check that matters most here is not "is every redirect valid" — it is the
-*cross-check*. Under the `latest-only` URL policy, a current-release page's
-`canonical_url` is the version-less path. That path is not a file; it only
-resolves because a redirect maps it onto the release. So a missing redirect turns
-a page's declared canonical URL into a 404 — and neither a redirect audit nor a
-frontmatter audit alone can see that, because each half looks correct in
-isolation.
+Checks that every redirect target exists, that no source is shadowed by a real
+file, that there are no chains (the plugin does not follow them), and that no map
+was left pointing at a superseded version after a version bump.
+
+`CANONICAL_UNREACHABLE` only applies under `--policy latest-only`, and is skipped
+otherwise: under the default `keep-all` a canonical is a versioned path, which is a
+real file, so it cannot depend on a redirect existing.
 """
 import os
 import re
@@ -44,8 +44,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("mkdocs_yml", nargs="?", default="en/mkdocs.yml")
     ap.add_argument("docs_root", nargs="?", default="en/docs")
-    ap.add_argument("--policy", default="latest-only",
-                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--policy", default="keep-all",
+                    choices=["keep-all", "latest-only", "strip-all"])
     ap.add_argument("--json", dest="json_out", default=None)
     ap.add_argument("--gate", action="store_true")
     args = ap.parse_args()
@@ -81,9 +81,7 @@ def main():
                 f"`{redirects[tgt]}`. The plugin does not follow chains, so this "
                 f"lands on a redirect stub.", src)
 
-    # 4. THE CROSS-CHECK. A current-release page's canonical is the version-less
-    #    path; that path must resolve via a redirect or a real file, or the
-    #    canonical URL 404s.
+    # 4. Only under latest-only: a version-less canonical needs a redirect to resolve.
     if args.policy == "latest-only":
         for rel in sorted(on_disk):
             ver, stripped = split_version(rel)

--- a/.claude/skills/wso2-doc-frontmatter/scripts/check_redirects.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/check_redirects.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate the mkdocs `redirects` plugin map, and cross-check it against frontmatter.
+
+    python3 scripts/check_redirects.py en/mkdocs.yml en/docs
+    python3 scripts/check_redirects.py en/mkdocs.yml en/docs --gate
+
+The check that matters most here is not "is every redirect valid" — it is the
+*cross-check*. Under the `latest-only` URL policy, a current-release page's
+`canonical_url` is the version-less path. That path is not a file; it only
+resolves because a redirect maps it onto the release. So a missing redirect turns
+a page's declared canonical URL into a 404 — and neither a redirect audit nor a
+frontmatter audit alone can see that, because each half looks correct in
+isolation.
+"""
+import os
+import re
+import sys
+import json
+import argparse
+import collections
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fm_lib import (  # noqa: E402
+    discover_versions, current_release, split_version, product_of, md_files,
+)
+
+
+def parse_redirect_maps(mkdocs_path):
+    """Pull `redirect_maps` out of mkdocs.yml without a full YAML load.
+
+    mkdocs.yml here contains custom tags and a very large nav, and a strict YAML
+    parse is both slow and prone to choking on them. The block is flat
+    `source: target` pairs, so a scoped regex is more robust than a full parse.
+    """
+    text = open(mkdocs_path, encoding="utf-8", errors="replace").read()
+    m = re.search(r"^\s*redirect_maps:\s*\n(.*?)(?=\n\s{0,4}\S|\Z)", text, re.S | re.M)
+    if not m:
+        return {}
+    pairs = re.findall(r"^\s+(\S+\.md):\s*(\S+\.md)\s*$", m.group(1), re.M)
+    return dict(pairs)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mkdocs_yml", nargs="?", default="en/mkdocs.yml")
+    ap.add_argument("docs_root", nargs="?", default="en/docs")
+    ap.add_argument("--policy", default="latest-only",
+                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--gate", action="store_true")
+    args = ap.parse_args()
+
+    root = args.docs_root.rstrip("/")
+    redirects = parse_redirect_maps(args.mkdocs_yml)
+    versions = discover_versions(root)
+    on_disk = set(md_files(root))
+
+    findings = []
+
+    def add(sev, code, msg, where=None):
+        findings.append({"severity": sev, "code": code, "message": msg, "where": where})
+
+    # 1. Every redirect target must exist.
+    for src, tgt in sorted(redirects.items()):
+        if tgt not in on_disk:
+            add("blocking", "REDIRECT_TARGET_MISSING",
+                f"`{src}` redirects to `{tgt}`, which is not a file in {root}.", src)
+
+    # 2. A redirect whose source is also a real file never fires.
+    for src, tgt in sorted(redirects.items()):
+        if src in on_disk:
+            add("should-fix", "REDIRECT_SHADOWED",
+                f"`{src}` exists as a real page, so its redirect to `{tgt}` never fires. "
+                f"Delete the redirect or the file.", src)
+
+    # 3. Redirect chains: the plugin does not follow them.
+    for src, tgt in sorted(redirects.items()):
+        if tgt in redirects:
+            add("blocking", "REDIRECT_CHAIN",
+                f"`{src}` -> `{tgt}`, but `{tgt}` is itself redirected to "
+                f"`{redirects[tgt]}`. The plugin does not follow chains, so this "
+                f"lands on a redirect stub.", src)
+
+    # 4. THE CROSS-CHECK. A current-release page's canonical is the version-less
+    #    path; that path must resolve via a redirect or a real file, or the
+    #    canonical URL 404s.
+    if args.policy == "latest-only":
+        for rel in sorted(on_disk):
+            ver, stripped = split_version(rel)
+            if ver is None:
+                continue
+            if ver != current_release(product_of(rel), versions):
+                continue
+            if stripped in redirects or stripped in on_disk:
+                continue
+            add("blocking", "CANONICAL_UNREACHABLE",
+                f"`{rel}` is the current release, so its canonical_url is the "
+                f"version-less `{stripped}` — but nothing resolves there. Add "
+                f"`{stripped}: {rel}` to redirect_maps, or that canonical URL 404s.", rel)
+
+    # 5. Redirects that skip the current release (a stale map after a version bump).
+    for src, tgt in sorted(redirects.items()):
+        tv = split_version(tgt)[0]
+        if not tv:
+            continue
+        cur = current_release(product_of(tgt), versions)
+        if cur and tv != cur and tv not in ("next", "latest"):
+            add("should-fix", "REDIRECT_STALE_VERSION",
+                f"`{src}` redirects to `{tgt}` (version {tv}) while the current "
+                f"release is {cur}. Likely a map that wasn't updated on the version bump.", src)
+
+    sev = collections.Counter(f["severity"] for f in findings)
+    codes = collections.Counter((f["code"], f["severity"]) for f in findings)
+
+    print("=" * 70)
+    print("REDIRECT CHECK")
+    print("=" * 70)
+    print(f"redirect_maps entries : {len(redirects)}")
+    print(f"pages on disk         : {len(on_disk)}")
+    print(f"total findings        : {len(findings)}"
+          f"   (blocking={sev['blocking']}, should-fix={sev['should-fix']})")
+    if codes:
+        print()
+        print(f"{'COUNT':>6}  {'SEVERITY':<11} CODE")
+        print("-" * 70)
+        for (c, s), n in codes.most_common():
+            print(f"{n:>6}  {s:<11} {c}")
+        print()
+        for f in findings:
+            print(f"  [{f['severity']}] {f['code']}: {f['message']}")
+    else:
+        print("\nNo redirect problems found.")
+
+    if args.json_out:
+        json.dump(findings, open(args.json_out, "w"), indent=1)
+        print(f"\nJSON -> {args.json_out}")
+
+    return 1 if (args.gate and sev["blocking"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wso2-doc-frontmatter/scripts/check_style.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/check_style.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Deterministic subset of the WSO2 style guide — the mechanical rules only.
+Judgement-heavy rules (tone, anthropomorphism, plain language) are left to the LLM skill."""
+import os, re, sys, json, collections
+
+import argparse
+_ap = argparse.ArgumentParser()
+_ap.add_argument("docs_root", nargs="?", default="en/docs")
+_ap.add_argument("--files", nargs="*", default=None, help="Limit to these paths.")
+_ap.add_argument("--json", dest="json_out", default=None,
+                 help="Write full findings to this path. Omitted = summary only.")
+_ap.add_argument("--gate", action="store_true", help="Exit 1 if any blocking finding.")
+_args = _ap.parse_args()
+DOCS = _args.docs_root.rstrip("/")
+TARGETS = _args.files or None
+
+SMALL = {"a","an","and","as","at","but","by","for","from","in","into","nor","of","on","onto","or",
+         "over","per","the","to","up","via","with","vs","near","off","out"}
+# Product/proper nouns and acronyms that legitimately stay capitalised mid-heading.
+PROPER = {"WSO2","API","APIs","AI","LLM","LLMs","MCP","REST","gRPC","GraphQL","JSON","YAML","XML",
+          "HTTP","HTTPS","OAuth","OAuth2","JWT","SSO","IdP","OIDC","SAML","TLS","mTLS","SSL","CORS",
+          "URL","URI","URLs","ID","IDs","UI","CLI","SDK","IDE","CI","CD","VM","VMs","K8s","Kubernetes",
+          "Docker","Helm","Istio","Envoy","Redis","PostgreSQL","MySQL","Oracle","Grafana","Prometheus",
+          "Jaeger","Zipkin","OpenTelemetry","OpenSearch","Elasticsearch","Moesif","Stripe","AWS","Azure",
+          "GCP","Bedrock","OpenAI","Anthropic","Gemini","Mistral","Ollama","Choreo","Bijira","Ballerina",
+          "Git","GitHub","GitLab","Linux","Windows","macOS","Java","Python","Go","Node","npm","Maven",
+          "Gradle","Swagger","OpenAPI","AsyncAPI","Postman","Portal","Gateway","Platform","Manager",
+          "Developer","Control","Plane","Hub","Workspace","Analytics","PII","RBAC","ACL","SLA","TPS",
+          "QPS","DNS","IP","TCP","UDP","gRPC-Web","Kafka","RabbitMQ","NGINX","Terraform","Ansible",
+          "Prometheus-compatible","Bitbucket","Vault","Keycloak","Okta","Auth0","Asgardeo","I","Step",
+          "Table","Contents","Note","Tip","Warning","Example","Appendix","FAQ","README","Enumerated","Values"}
+
+# Phrase-level allowlist: matched case-sensitively and masked out BEFORE per-word
+# scanning, because multi-word product names cannot be expressed as single words.
+PROPER_PHRASES = {
+    # Third-party products / cloud services
+    "Google Cloud Trace","Google Cloud Monitoring","Google Cloud","Azure AI Content Safety",
+    "Azure Content Safety Content Moderation","Azure Content Safety Guardrail",
+    "Azure Content Safety","Azure OpenAI","AWS Bedrock Guardrails","AWS Bedrock Guardrail",
+    "Docker Compose","OpenSearch Dashboards","VS Code","Server-Sent Events",
+    # Kubernetes API kinds / concepts
+    "Horizontal Pod Autoscaler","Pod Disruption Budget","Custom Resource Definition",
+    "Service Account","ConfigMap","StatefulSet","DaemonSet","HTTPRoute","Gateway API",
+    # Standards
+    "JSON Schema Draft 7","JSON Schema","JSONPath",
+    # WSO2 components (capitalised-dominant in the corpus)
+    "Gateway Controller","Developer Portal","Control Plane","Policy Hub","Policy Engine",
+    "Gateway Builder","Event Gateway","API Platform Console","API Platform","MCP Proxy","API Proxy",
+    # --- Policy Hub policy names -------------------------------------------------
+    # Treated as proper nouns, matching the Policy Hub catalogue. Remove this block
+    # if policy names should instead follow sentence case.
+    "Model Weighted Round Robin","Model Round Robin","Sentence Count Guardrail",
+    "Word Count Guardrail","Content Length Guardrail","JSON Schema Guardrail",
+    "Regex Guardrail","URL Guardrail","Semantic Prompt Guard","Semantic Tool Filtering",
+    "PII Masking","Analytics Header Filter","Subscription Validation",
+    "API Key Auth","Basic Auth","JWT Auth","Rate Limit",
+}
+# Conventional release-stage / status labels never count as Title Case evidence.
+STATUS_LABELS = {"beta","alpha","ga","preview","deprecated","optional","experimental",
+                 "recommended","required","default","new","legacy"}
+_PHRASES = sorted(PROPER_PHRASES, key=len, reverse=True)
+
+RULES = [
+    # (code, severity, regex, message, section, quoted rule)
+    ("QUALITATIVE", "should-fix",
+     r"\b(simply|simple|easy|easily|just\s+(?:click|run|add|set|use)|quick|quickly|straightforward|effortless|trivial|obviously|of\s+course)\b",
+     "Qualitative/minimising language — it tells the reader how hard the task should feel.",
+     "Voice, tone, and audience", "No qualitative language."),
+    ("PLEASE", "should-fix", r"\bplease\b",
+     "Drop \"please\" from instructions — documentation instructions are imperative, not requests.",
+     "Voice, tone, and audience", "Explicitly called out to avoid:"),
+    ("TIMELESS", "should-fix",
+     r"\b(currently|at\s+the\s+moment|for\s+now|at\s+present|presently|as\s+of\s+(?:now|today|this\s+release)|recently|soon|in\s+the\s+near\s+future|upcoming|newly|brand[-\s]new|latest\s+version|new\s+feature|will\s+be\s+(?:released|available|supported)|coming\s+soon|not\s+yet\s+supported|future\s+release)\b",
+     "Time-bound wording — it dates the page and goes stale without anyone editing it.",
+     "Timeless documentation", "Avoid these words/phrases when describing product or feature capabilities:"),
+    ("EN_DASH", "blocking", r"–",
+     "En dash used. The guide bans en dashes outright.",
+     "Grammar and punctuation", "En dashes: don't use them. Use a hyphen or the word \"to\" instead."),
+    ("EM_DASH_SPACED", "polish", r"\s—|—\s",
+     "Em dash with surrounding spaces. Common enough across the docs to be a house convention rather than a slip — raise it once as a convention question, not as hundreds of findings.",
+     "Grammar and punctuation", "Em dash (—): no space before or after"),
+    ("CLICK_HERE", "blocking", r"\[\s*(?:click\s+here|here|this\s+link|read\s+more|more|link)\s*\]\(",
+     "Non-descriptive link text.",
+     "Formatting and typography", "Link text: short, unique, descriptive phrases that give context for the destination"),
+    ("BARE_URL_LINK", "should-fix", r"\[\s*https?://[^\]]+\]\(",
+     "Bare URL used as the link text.",
+     "Formatting and typography", "(Never \"click here\" or a bare URL.)"),
+    ("FUTURE_TENSE", "polish", r"\b(?:will|shall)\s+(?:be\s+)?(?:see|need|want|have|get|find|notice|receive|return|display|show|create|appear)\b",
+     "Future tense where present tense reads better.",
+     "Voice, tone, and audience", "Active voice, present tense, indicative/imperative mood."),
+    ("THE_USER", "should-fix", r"\bthe\s+user(?:'s)?\b(?!\s+(?:name|id|ID|attribute|claim|pool|store|directory|token|credential|context|identity))",
+     "Refers to \"the user\" instead of addressing the reader as \"you\".",
+     "Voice, tone, and audience", "Second person for the reader."),
+    ("WE_US", "should-fix", r"\b(?:we|us|our)\b(?!\s*[-—])",
+     "First person plural for product behaviour.",
+     "Voice, tone, and audience", "Third person for WSO2 actions and features."),
+]
+
+def in_code_or_url(text):
+    """Return a set of char indices inside fenced code, inline code, links' URL part, or HTML."""
+    mask = bytearray(len(text))
+    for m in re.finditer(r"```.*?```|~~~.*?~~~", text, re.S): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"`[^`\n]*`", text): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"<!--.*?-->", text, re.S): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"<[^>]+>", text): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"\]\([^)]*\)", text): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"^(?: {4}|\t).*$", text, re.M): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"https?://\S+", text): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    for m in re.finditer(r"^---\n.*?\n---", text, re.S): mask[m.start():m.end()] = b"\x01"*(m.end()-m.start())
+    return mask
+
+def title_case_violation(h):
+    """Judge a heading against 'sentence case, always'.
+
+    Returns (n_offenders, offenders). The caller decides severity: >=2 offenders is
+    a confident Title Case verdict; exactly 1 is reported at lower severity, because
+    a single stray capital is often a product name the allowlist doesn't know yet.
+    """
+    core = re.sub(r"\{#[\w-]+\}", "", h)
+    core = re.sub(r"`[^`]*`", " ", core)                       # code spans are literals
+    core = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", core)     # keep link text only
+    core = re.sub(r"<[^>]+>", " ", core)
+
+    # Mask known multi-word proper names so their constituent words aren't scanned.
+    for ph in _PHRASES:
+        core = core.replace(ph, " \x00 ")
+
+    # Label-prefix rule: a heading may be split by MORE THAN ONE ':' / ';' / spaced
+    # dash. Each segment gets its own exempt first word, so split on every boundary.
+    segments = [sg for sg in re.split(r"[:;]|\s[-\u2013\u2014]\s", core) if sg.strip()]
+
+    offenders = []
+    total_words = 0
+    for seg in segments:
+        words = re.findall(r"[A-Za-z][A-Za-z0-9'\u2019\-\.]*", seg)
+        total_words += len(words)
+        for w in words[1:]:                                    # first word of each segment is exempt
+            bare = w.rstrip(".").strip("'\u2019")
+            if bare in PROPER or bare.upper() == bare:          # acronym or known proper noun
+                continue
+            if bare.lower() in STATUS_LABELS:                   # (Beta), (Optional), ...
+                continue
+            if re.match(r"^[A-Z][a-z]", bare):
+                offenders.append(w)
+    if total_words < 3:
+        return 0, []
+    return len(offenders), offenders
+
+findings = []
+files = []
+if TARGETS:
+    files = [os.path.relpath(t, DOCS) if t.startswith(DOCS) else t for t in TARGETS]
+else:
+    for root, _, fs in os.walk(DOCS):
+        for f in sorted(fs):
+            if f.endswith(".md"): files.append(os.path.relpath(os.path.join(root, f), DOCS))
+files.sort()
+
+for rel in files:
+    full = os.path.join(DOCS, rel)
+    if not os.path.exists(full): continue
+    txt = open(full, encoding="utf-8", errors="replace").read()
+    mask = in_code_or_url(txt)
+    lines = txt.split("\n")
+    # line start offsets
+    offs, acc = [], 0
+    for ln in lines: offs.append(acc); acc += len(ln) + 1
+
+    for code, sev, pat, msg, section, rule in RULES:
+        for m in re.finditer(pat, txt, re.I):
+            if mask[m.start()] == 1: continue
+            ln = max(i for i, o in enumerate(offs) if o <= m.start()) + 1
+            findings.append({"file": rel, "line": ln, "severity": sev, "code": code,
+                             "match": m.group(0).strip(), "message": msg,
+                             "section": section, "rule": rule})
+
+    in_fence = False
+    for i, ln in enumerate(lines, 1):
+        if re.match(r"^\s*(```|~~~)", ln): in_fence = not in_fence; continue
+        if in_fence: continue
+        hm = re.match(r"^(#{1,6})\s+(.+?)\s*$", ln)
+        if hm:
+            n, offenders = title_case_violation(hm.group(2))
+            if n >= 2:
+                findings.append({"file": rel, "line": i, "severity": "blocking", "code": "HEADING_TITLE_CASE",
+                                 "match": hm.group(2), "message": f"Heading is in Title Case (capitalised: {', '.join(offenders)}).",
+                                 "section": "Formatting and typography",
+                                 "rule": "Headings and titles: sentence case, always."})
+            elif n == 1:
+                findings.append({"file": rel, "line": i, "severity": "should-fix", "code": "HEADING_CASE_SINGLE_WORD",
+                                 "match": hm.group(2), "message": f"Heading has one unexpected capital: {offenders[0]}. Lowercase it, or add it to the proper-noun allowlist if it is a product name.",
+                                 "section": "Formatting and typography",
+                                 "rule": "Headings and titles: sentence case, always."})
+
+by = collections.Counter((f["code"], f["severity"]) for f in findings)
+print("=" * 68); print("STYLE CHECK (deterministic rules only)"); print("=" * 68)
+print(f"files scanned  : {len(files)}")
+print(f"total findings : {len(findings)}")
+print()
+print(f"{'COUNT':>6}  {'SEV':<11} CODE"); print("-" * 68)
+for (c, s), n in by.most_common(): print(f"{n:>6}  {s:<11} {c}")
+if _args.json_out:
+    json.dump(findings, open(_args.json_out, "w"), indent=1)
+    print(f"\n(full findings -> {_args.json_out})")
+else:
+    print("\n(re-run with --json <path> for the full findings list)")
+
+if _args.gate and any(f["severity"] == "blocking" for f in findings):
+    sys.exit(1)

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_audit.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_audit.py
@@ -68,8 +68,8 @@ def main():
     ap.add_argument("docs_root", nargs="?", default="en/docs")
     ap.add_argument("--files", nargs="*", default=None,
                     help="Limit to these paths (relative to docs_root or to cwd).")
-    ap.add_argument("--policy", default="latest-only",
-                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--policy", default="keep-all",
+                    choices=["keep-all", "latest-only", "strip-all"])
     ap.add_argument("--json", dest="json_out", default=None)
     ap.add_argument("--gate", action="store_true", help="Exit 1 if any blocking issue.")
     ap.add_argument("--quiet", action="store_true")

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_audit.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_audit.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Validate frontmatter across the WSO2 API Platform docs. Read-only.
+
+    python3 scripts/fm_audit.py en/docs                     # human summary
+    python3 scripts/fm_audit.py en/docs --json out.json     # machine-readable
+    python3 scripts/fm_audit.py en/docs --policy strip-all   # audit as-is today
+    python3 scripts/fm_audit.py en/docs --files a.md b.md    # just these files
+    python3 scripts/fm_audit.py en/docs --gate               # exit 1 on blocking
+
+Exit codes: 0 clean (or no blocking issues), 1 blocking issues found with --gate.
+"""
+import os
+import sys
+import json
+import argparse
+import collections
+import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fm_lib import (  # noqa: E402
+    BASE, REQUIRED, AUTHOR, DESC_MAX, DESC_MIN, TITLE_MAX,
+    effective_allowed_ct, CT_ALIASES, discover_versions, site_paths,
+    split_frontmatter, md_files, norm_date, split_version,
+    load_frontmatter, parse_frontmatter_yaml, HAVE_PYYAML, is_legacy_url,
+)
+
+
+def selftest(root):
+    """Prove the dependency-free parser agrees with PyYAML on every real page.
+
+    Only meaningful where PyYAML is installed — that is the point: run it once
+    somewhere it is available, and you can trust the fallback everywhere it isn't.
+    """
+    if not HAVE_PYYAML:
+        print("PyYAML is not installed here, so there is nothing to compare against.")
+        print("Run --selftest on a machine that has it; the fallback is what runs otherwise.")
+        return 0
+    import yaml
+    checked = mismatched = 0
+    for rel in md_files(root):
+        raw, _ = split_frontmatter(open(os.path.join(root, rel), encoding="utf-8",
+                                       errors="replace").read())
+        if raw is None:
+            continue
+        try:
+            ref = yaml.safe_load(raw) or {}
+        except Exception:
+            continue
+        try:
+            got = parse_frontmatter_yaml(raw)
+        except ValueError as e:
+            print(f"  FALLBACK REFUSED {rel}: {e}")
+            mismatched += 1
+            continue
+        checked += 1
+        if got != ref:
+            mismatched += 1
+            print(f"  MISMATCH {rel}")
+            for k in sorted(set(ref) | set(got)):
+                if ref.get(k) != got.get(k):
+                    print(f"     {k}: pyyaml={ref.get(k)!r}  fallback={got.get(k)!r}")
+    print(f"\nself-test: {checked} pages compared, {mismatched} mismatch(es).")
+    return 1 if mismatched else 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("docs_root", nargs="?", default="en/docs")
+    ap.add_argument("--files", nargs="*", default=None,
+                    help="Limit to these paths (relative to docs_root or to cwd).")
+    ap.add_argument("--policy", default="latest-only",
+                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--gate", action="store_true", help="Exit 1 if any blocking issue.")
+    ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--selftest", action="store_true",
+                    help="Verify the built-in YAML parser against PyYAML on every page.")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest(args.docs_root.rstrip("/"))
+
+    root = args.docs_root.rstrip("/")
+    versions = discover_versions(root)
+    allowed_ct = effective_allowed_ct()
+
+    if args.files:
+        files = []
+        for f in args.files:
+            f = f.replace("\\", "/")
+            files.append(f[len(root) + 1:] if f.startswith(root + "/") else f)
+    else:
+        files = md_files(root)
+
+    findings = []
+
+    def add(rel, sev, code, msg, fix=None):
+        f = {"file": rel, "severity": sev, "code": code, "message": msg}
+        if fix:
+            f["suggested"] = fix
+        findings.append(f)
+
+    canon_map, mdurl_map = collections.defaultdict(list), collections.defaultdict(list)
+    stats = collections.Counter()
+
+    for rel in files:
+        full = os.path.join(root, rel)
+        if not os.path.isfile(full):
+            continue
+        stats["scanned"] += 1
+        text = open(full, encoding="utf-8", errors="replace").read()
+        raw, body = split_frontmatter(text)
+
+        if raw is None:
+            add(rel, "blocking", "FM_MISSING",
+                "No frontmatter block. Every page under en/docs/ needs one.")
+            stats["no_fm"] += 1
+            continue
+        try:
+            fm = load_frontmatter(raw)
+        except Exception as e:
+            add(rel, "blocking", "FM_YAML_INVALID", f"Frontmatter is not valid YAML: {str(e)[:150]}")
+            stats["yaml_err"] += 1
+            continue
+        if not isinstance(fm, dict):
+            add(rel, "blocking", "FM_NOT_MAPPING", "Frontmatter is not a YAML mapping.")
+            continue
+
+        before = len(findings)
+
+        for k in REQUIRED:
+            if k == "author" and "authors" in fm:
+                continue
+            if k not in fm or fm[k] in (None, "", []):
+                add(rel, "blocking", "FM_FIELD_MISSING", f"Required field `{k}` is missing or empty.")
+
+        ct = fm.get("content_type")
+        if ct is not None:
+            cts = str(ct).strip().strip('"').lower()
+            if cts not in allowed_ct:
+                mapped = CT_ALIASES.get(cts)
+                add(rel, "blocking", "CT_INVALID",
+                    f"content_type `{ct}` is not in the allowed set "
+                    f"({', '.join(sorted(allowed_ct))}).",
+                    fix=f"content_type: {mapped}" if mapped else None)
+
+        d = fm.get("description")
+        if isinstance(d, str):
+            if len(d) > DESC_MAX:
+                add(rel, "blocking", "DESC_TOO_LONG",
+                    f"description is {len(d)} chars; the rule caps it at {DESC_MAX}. "
+                    f"Needs a human/LLM rewrite, not a truncation.")
+            elif len(d) < DESC_MIN:
+                add(rel, "should-fix", "DESC_TOO_SHORT",
+                    f"description is only {len(d)} chars — too thin to be useful for search or agents.")
+
+        t = fm.get("title")
+        if isinstance(t, str) and len(t) > TITLE_MAX:
+            add(rel, "should-fix", "TITLE_TOO_LONG",
+                f"title is {len(t)} chars — likely to truncate on narrow devices.")
+
+        exp_canon, exp_md = site_paths(rel, versions, args.policy)
+        cu = str(fm.get("canonical_url", "")).strip()
+        mu = str(fm.get("md_url", "")).strip()
+        if cu and cu.rstrip("/") + "/" != exp_canon.rstrip("/") + "/":
+            add(rel, "blocking", "CANON_MISMATCH",
+                f"canonical_url does not match the file path under the `{args.policy}` policy.",
+                fix=f"canonical_url: {exp_canon}")
+        if mu and mu != exp_md:
+            add(rel, "blocking", "MDURL_MISMATCH",
+                f"md_url does not match the file path under the `{args.policy}` policy.",
+                fix=f"md_url: {exp_md}")
+        for k in ("canonical_url", "md_url"):
+            v = str(fm.get(k, ""))
+            if is_legacy_url(v):
+                add(rel, "blocking", "STALE_DOMAIN",
+                    f"{k} still points at a pre-migration domain: `{v}`")
+
+        tg = fm.get("tags")
+        if tg is not None and not isinstance(tg, list):
+            add(rel, "blocking", "TAGS_NOT_LIST", "tags must be a YAML list, so agents can parse it.")
+        elif isinstance(tg, list):
+            if len(tg) < 2:
+                add(rel, "should-fix", "TAGS_TOO_FEW",
+                    f"only {len(tg)} tag(s). 2-5 lets agents relate this page to neighbours.")
+            bad = [x for x in tg if not isinstance(x, str) or x != x.lower()]
+            if bad:
+                add(rel, "should-fix", "TAGS_CASE", f"tags should be lowercase: {bad}")
+
+        # House rule: `author` is always the team string. The style guide's own
+        # note says "We currently just use 'WSO2 API Platform Documentation
+        # Team'"; its named-individual example is illustrative only. Multiple
+        # authors still use the plural `authors` list, which is left alone.
+        a = fm.get("author")
+        if a is not None:
+            if not str(a).strip():
+                add(rel, "blocking", "AUTHOR_EMPTY",
+                    f"author is empty. Use `{AUTHOR}`.", fix=f"author: {AUTHOR}")
+            elif str(a).strip().strip('"') != AUTHOR:
+                add(rel, "should-fix", "AUTHOR_NONSTANDARD",
+                    f"author is `{a}`, expected `{AUTHOR}`.", fix=f"author: {AUTHOR}")
+
+        lu = fm.get("last_updated")
+        if lu is not None:
+            s = norm_date(lu)
+            if s is None:
+                add(rel, "blocking", "DATE_FORMAT", f"last_updated `{lu}` is not YYYY-MM-DD.")
+            else:
+                try:
+                    if datetime.date.fromisoformat(s) > datetime.date.today():
+                        add(rel, "should-fix", "DATE_FUTURE", f"last_updated `{s}` is in the future.")
+                except ValueError:
+                    add(rel, "blocking", "DATE_INVALID", f"last_updated `{lu}` is not a real date.")
+
+        if cu:
+            canon_map[cu].append(rel)
+        if mu:
+            mdurl_map[mu].append(rel)
+        if len(findings) == before:
+            stats["clean"] += 1
+
+    # Cross-file: only one file can be served at a given .md path.
+    for mu, owners in sorted(mdurl_map.items()):
+        if len(owners) > 1:
+            vers = [split_version(o)[0] or "-" for o in owners]
+            for o in owners:
+                add(o, "blocking", "MDURL_COLLISION",
+                    f"md_url `{mu}` is claimed by {len(owners)} files (versions: {', '.join(vers)}). "
+                    f"Only one can be served there, so the rest are unreachable as Markdown.")
+    for cu, owners in sorted(canon_map.items()):
+        if len(owners) > 1:
+            for o in owners:
+                add(o, "should-fix", "CANON_SHARED",
+                    f"canonical_url `{cu}` is shared by {len(owners)} files: {', '.join(owners)}. "
+                    f"Search engines will treat only one as the real page.")
+
+    sev = collections.Counter(f["severity"] for f in findings)
+    codes = collections.Counter((f["code"], f["severity"]) for f in findings)
+
+    if not args.quiet:
+        print("=" * 70)
+        print(f"FRONTMATTER AUDIT   (url policy: {args.policy})")
+        print("=" * 70)
+        print(f"files scanned    : {stats['scanned']}")
+        print(f"fully clean      : {stats['clean']}")
+        print(f"no frontmatter   : {stats['no_fm']}")
+        print(f"unparseable YAML : {stats['yaml_err']}")
+        print(f"total findings   : {len(findings)}"
+              f"   (blocking={sev['blocking']}, should-fix={sev['should-fix']}, polish={sev['polish']})")
+        if codes:
+            print()
+            print(f"{'COUNT':>6}  {'SEVERITY':<11} CODE")
+            print("-" * 70)
+            for (c, s), n in codes.most_common():
+                print(f"{n:>6}  {s:<11} {c}")
+        if versions:
+            print()
+            print("versioned products detected:")
+            for p, vs in sorted(versions.items()):
+                print(f"  {p or '<root>'}: {', '.join(vs)}")
+
+    if args.json_out:
+        json.dump({"policy": args.policy, "stats": dict(stats), "findings": findings},
+                  open(args.json_out, "w"), indent=1)
+        if not args.quiet:
+            print(f"\nJSON -> {args.json_out}")
+
+    if args.gate and sev["blocking"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_fix.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_fix.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Repair the *mechanical* parts of frontmatter, and scaffold what needs judgement.
+
+Two things this script deliberately will NOT invent: `title` and `description`.
+Those are the fields a reader and a search engine actually see, and a generated
+one is worse than none. Everything derivable from the path, the H1 or git
+history is filled in automatically; anything requiring judgement is emitted as a
+worklist for the LLM to fill.
+
+    # See what would change — always run this first.
+    python3 scripts/fm_fix.py en/docs --dry-run
+
+    # Fix mechanical fields in place on files that already have frontmatter.
+    python3 scripts/fm_fix.py en/docs --apply
+
+    # Add a frontmatter block to files that have none. title comes from the H1;
+    # description/tags/content_type are left as TODO and listed in the worklist.
+    python3 scripts/fm_fix.py en/docs --scaffold --apply --worklist work.json
+
+    # Fill in the TODO fields the LLM decided on.
+    python3 scripts/fm_fix.py en/docs --fill filled.json --apply
+
+`filled.json` format:
+    {"cloud/api-platform-gateway/analytics.md":
+        {"description": "...", "tags": ["a","b"], "content_type": "reference",
+         "title": "optional override"}}
+"""
+import os
+import re
+import sys
+import json
+import argparse
+import collections
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fm_lib import (  # noqa: E402
+    REQUIRED, AUTHOR, DESC_MAX, effective_allowed_ct, CT_ALIASES,
+    discover_versions, site_paths, split_frontmatter, md_files,
+    norm_date, git_last_modified, first_h1, render_frontmatter, load_frontmatter,
+)
+
+TODO = "TODO"
+
+
+def sentence_case(s):
+    """Lowercase a Title Case heading, preserving acronyms and the first word."""
+    words = s.split()
+    out = []
+    for i, w in enumerate(words):
+        core = w.strip("()[],.:;")
+        if i == 0 or core.upper() == core or not re.match(r"^[A-Z][a-z]+$", core):
+            out.append(w)
+        else:
+            out.append(w[0].lower() + w[1:])
+    return " ".join(out)
+
+
+def derive_tags(rel):
+    """Path segments make honest default tags: they are what the page is filed under."""
+    from fm_lib import VER_RE, INDEXY
+    parts = [p for p in os.path.dirname(rel).split("/") if p and not VER_RE.match(p)]
+    stem = os.path.basename(rel)[:-3]
+    if stem in INDEXY:
+        stem = None
+    tags = [p.lower() for p in parts]
+    if stem and stem.lower() not in tags:
+        tags.append(stem.lower())
+    seen, out = set(), []
+    for t in tags[:4]:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out or ["docs"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("docs_root", nargs="?", default="en/docs")
+    ap.add_argument("--files", nargs="*", default=None)
+    ap.add_argument("--policy", default="latest-only",
+                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--apply", action="store_true", help="Write changes to disk.")
+    ap.add_argument("--dry-run", action="store_true", help="Report only (default).")
+    ap.add_argument("--scaffold", action="store_true",
+                    help="Also add a block to files that have no frontmatter.")
+    ap.add_argument("--fill", default=None, help="JSON of LLM-decided field values.")
+    ap.add_argument("--worklist", default=None,
+                    help="Write the list of files needing LLM judgement here.")
+    ap.add_argument("--repo-root", default=".", help="For `git log` dates.")
+    args = ap.parse_args()
+
+    if not args.apply:
+        args.dry_run = True
+    root = args.docs_root.rstrip("/")
+    versions = discover_versions(root)
+    allowed_ct = effective_allowed_ct()
+    filled = json.load(open(args.fill)) if args.fill else {}
+
+    files = args.files or md_files(root)
+    files = [f[len(root) + 1:] if f.startswith(root + "/") else f for f in files]
+
+    changes = collections.Counter()
+    worklist, edited = [], []
+
+    for rel in sorted(files):
+        full = os.path.join(root, rel)
+        if not os.path.isfile(full):
+            continue
+        text = open(full, encoding="utf-8", errors="replace").read()
+        raw, body = split_frontmatter(text)
+        given = filled.get(rel, {})
+        need = []
+
+        if raw is None:
+            if not args.scaffold:
+                continue
+            fm = {}
+            h1 = first_h1(body)
+            fm["title"] = given.get("title") or (sentence_case(h1) if h1 else TODO)
+            if fm["title"] == TODO:
+                need.append("title")
+            fm["description"] = given.get("description", TODO)
+            if fm["description"] == TODO:
+                need.append("description")
+            fm["tags"] = given.get("tags") or derive_tags(rel)
+            fm["author"] = AUTHOR
+            fm["last_updated"] = git_last_modified(os.path.join(root, rel), args.repo_root)
+            ct = given.get("content_type", TODO)
+            fm["content_type"] = ct
+            if ct == TODO:
+                need.append("content_type")
+            fm["canonical_url"], fm["md_url"] = site_paths(rel, versions, args.policy)
+            need = [n for n in need if not given.get(n)]
+            new_text = render_frontmatter(fm, REQUIRED) + "\n\n" + body.lstrip("\n")
+            changes["scaffolded"] += 1
+        else:
+            try:
+                fm = load_frontmatter(raw)
+            except Exception:
+                print(f"  SKIP (unparseable YAML): {rel}")
+                changes["skipped_yaml"] += 1
+                continue
+            if not isinstance(fm, dict):
+                changes["skipped_yaml"] += 1
+                continue
+            orig = dict(fm)
+
+            # --- mechanical, safe to automate -------------------------------
+            canon, md = site_paths(rel, versions, args.policy)
+            if str(fm.get("canonical_url", "")).strip() != canon:
+                fm["canonical_url"] = canon
+                changes["canonical_url"] += 1
+            if str(fm.get("md_url", "")).strip() != md:
+                fm["md_url"] = md
+                changes["md_url"] += 1
+
+            ct = str(fm.get("content_type", "")).strip().strip('"').lower()
+            if ct and ct not in allowed_ct:
+                if ct in CT_ALIASES:
+                    fm["content_type"] = CT_ALIASES[ct]
+                    changes["content_type_mapped"] += 1
+                else:
+                    need.append("content_type")
+            elif not ct:
+                need.append("content_type")
+
+            # House rule: `author` is always the team string. A page with
+            # multiple authors uses the plural `authors` list instead, and that
+            # is left untouched.
+            if "authors" not in fm and str(fm.get("author", "")).strip().strip('"') != AUTHOR:
+                fm["author"] = AUTHOR
+                changes["author"] += 1
+
+            nd = norm_date(fm.get("last_updated"))
+            if nd is None:
+                fm["last_updated"] = git_last_modified(os.path.join(root, rel), args.repo_root)
+                changes["last_updated"] += 1
+            else:
+                fm["last_updated"] = nd
+
+            tg = fm.get("tags")
+            if isinstance(tg, list):
+                low = [str(t).lower() for t in tg]
+                if low != tg:
+                    fm["tags"] = low
+                    changes["tags_lowercased"] += 1
+                if len(low) < 2:
+                    need.append("tags")
+            elif tg in (None, "", []):
+                fm["tags"] = derive_tags(rel)
+                changes["tags_derived"] += 1
+            else:
+                fm["tags"] = [str(tg).lower()]
+                changes["tags_listified"] += 1
+
+            # --- needs judgement: never auto-written ------------------------
+            if given.get("description"):
+                fm["description"] = given["description"]
+                changes["description_filled"] += 1
+            d = fm.get("description")
+            if not isinstance(d, str) or not d.strip():
+                need.append("description")
+            elif len(d) > DESC_MAX:
+                need.append("description")   # rewrite, never truncate
+
+            if given.get("title"):
+                fm["title"] = given["title"]
+                changes["title_filled"] += 1
+            if given.get("content_type"):
+                fm["content_type"] = given["content_type"]
+                changes["content_type_filled"] += 1
+            if given.get("tags"):
+                fm["tags"] = [str(t).lower() for t in given["tags"]]
+                changes["tags_filled"] += 1
+
+            if not str(fm.get("title", "")).strip():
+                need.append("title")
+
+            # Anything the --fill payload supplied is no longer outstanding.
+            need = [n for n in need if not given.get(n)]
+
+            del orig
+            # Compare the *rendered* result, not the parsed dict: YAML gives dates
+            # back as date objects, so a dict compare reports a change on every
+            # file even when the serialised output is byte-identical.
+            new_text = render_frontmatter(fm, REQUIRED) + "\n\n" + body.lstrip("\n")
+            if new_text == text:
+                if need:
+                    worklist.append({"file": rel, "needs": sorted(set(need)),
+                                     "h1": first_h1(body),
+                                     "current": {k: fm.get(k) for k in ("title", "description", "content_type", "tags")}})
+                continue
+
+        if need:
+            worklist.append({"file": rel, "needs": sorted(set(need)),
+                             "h1": first_h1(body),
+                             "current": {k: fm.get(k) for k in ("title", "description", "content_type", "tags")}})
+        edited.append(rel)
+        if args.apply:
+            open(full, "w", encoding="utf-8").write(new_text)
+
+    print("=" * 70)
+    print(f"FRONTMATTER FIX   ({'APPLIED' if args.apply else 'DRY RUN'}, policy: {args.policy})")
+    print("=" * 70)
+    print(f"files touched : {len(edited)}")
+    if changes:
+        print()
+        for k, v in changes.most_common():
+            print(f"  {v:5d}  {k}")
+    print(f"\nfiles still needing LLM judgement: {len(worklist)}")
+    if worklist:
+        c = collections.Counter(n for w in worklist for n in w["needs"])
+        for k, v in c.most_common():
+            print(f"  {v:5d}  {k}")
+    if args.worklist:
+        json.dump(worklist, open(args.worklist, "w"), indent=1)
+        print(f"\nworklist -> {args.worklist}")
+    if not args.apply:
+        print("\n(nothing written — re-run with --apply)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_fix.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_fix.py
@@ -77,8 +77,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("docs_root", nargs="?", default="en/docs")
     ap.add_argument("--files", nargs="*", default=None)
-    ap.add_argument("--policy", default="latest-only",
-                    choices=["latest-only", "strip-all", "keep-all"])
+    ap.add_argument("--policy", default="keep-all",
+                    choices=["keep-all", "latest-only", "strip-all"])
     ap.add_argument("--apply", action="store_true", help="Write changes to disk.")
     ap.add_argument("--dry-run", action="store_true", help="Report only (default).")
     ap.add_argument("--scaffold", action="store_true",

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_lib.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_lib.py
@@ -3,12 +3,12 @@
 
 The one thing worth understanding before changing anything here: this repo keeps
 several *versions* of the same page on disk (``<product>/1.0.0/x.md``,
-``<product>/1.1.0/x.md``, ``<product>/next/x.md``) but the published site serves
-the newest release at a *version-less* URL, with mkdocs `redirects` mapping the
-version-less path onto the current release's file.
+``<product>/1.1.0/x.md``, ``<product>/next/x.md``), and every one of them is
+published at a URL that includes its version segment — the latest release included.
+A version-less URL redirects to the versioned page rather than serving content.
 
-That makes the version segment the only genuinely tricky part of deriving a URL
-from a path, so it is all funnelled through :func:`site_paths` below.
+That makes the version segment the only genuinely tricky part of deriving a URL from
+a path, so it is all funnelled through :func:`site_paths` below.
 """
 import os
 import re
@@ -241,17 +241,14 @@ def current_release(product, versions_map):
     return vs[-1] if vs else None
 
 
-def site_paths(rel, versions_map=None, policy="latest-only"):
+def site_paths(rel, versions_map=None, policy="keep-all"):
     """Derive (canonical_url, md_url) for a repo-relative Markdown path.
 
     policy:
-      "latest-only"  RECOMMENDED. The current release gets the version-less URL;
-                     every other version keeps its version segment. This is the
-                     only policy under which each file owns a unique md_url.
-      "strip-all"    What the repo does today: every version claims the
-                     version-less URL. Produces collisions between versions.
-      "keep-all"     Every version, including the current release, keeps its
-                     segment. Unique, but no stable "latest" URL.
+      "keep-all"     DEFAULT, and what the site does. Every version keeps its
+                     segment, latest release included.
+      "latest-only"  Gives the latest release a version-less URL.
+      "strip-all"    Every version claims one version-less URL. Collides.
     """
     versions_map = versions_map if versions_map is not None else {}
     ver, stripped = split_version(rel)

--- a/.claude/skills/wso2-doc-frontmatter/scripts/fm_lib.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/fm_lib.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Shared frontmatter logic for the WSO2 API Platform docs repo.
+
+The one thing worth understanding before changing anything here: this repo keeps
+several *versions* of the same page on disk (``<product>/1.0.0/x.md``,
+``<product>/1.1.0/x.md``, ``<product>/next/x.md``) but the published site serves
+the newest release at a *version-less* URL, with mkdocs `redirects` mapping the
+version-less path onto the current release's file.
+
+That makes the version segment the only genuinely tricky part of deriving a URL
+from a path, so it is all funnelled through :func:`site_paths` below.
+"""
+import os
+import re
+import subprocess
+import datetime
+
+# ---------------------------------------------------------------------------
+# YAML loading, with a dependency-free fallback.
+#
+# PyYAML is nicer, but requiring `pip install` is real friction — on macOS with
+# Homebrew Python, a plain `pip install` is refused outright (PEP 668), and in CI
+# it is one more step to get wrong. Frontmatter here is flat: scalars, block
+# lists, and comments. That is a small enough grammar to parse directly, so the
+# scripts run on a bare `python3` with nothing installed.
+#
+# The fallback is validated against PyYAML across every page in the repo; see
+# `--selftest` in fm_audit.py.
+# ---------------------------------------------------------------------------
+try:
+    import yaml as _yaml
+except ImportError:
+    _yaml = None
+
+
+def _strip_comment(v):
+    """Remove a trailing ` # comment`, but never inside quotes or a URL."""
+    out, quote = [], None
+    for i, ch in enumerate(v):
+        if quote:
+            out.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            out.append(ch)
+            continue
+        if ch == "#" and (i == 0 or v[i - 1] in " \t"):
+            break
+        out.append(ch)
+    return "".join(out).strip()
+
+
+def _scalar(v):
+    """Coerce a YAML scalar the way safe_load would, for the subset we use."""
+    v = _strip_comment(v)
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+        inner = v[1:-1]
+        if v[0] == '"':
+            inner = inner.replace('\\"', '"').replace("\\\\", "\\")
+        return inner
+    if v in ("", "~", "null"):
+        return None
+    if v in ("true", "True"):
+        return True
+    if v in ("false", "False"):
+        return False
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", v):
+        try:
+            return datetime.date.fromisoformat(v)   # match PyYAML's date typing
+        except ValueError:
+            return v
+    if re.match(r"^-?\d+$", v):
+        return int(v)
+    if re.match(r"^\[.*\]$", v):                    # inline flow list
+        body = v[1:-1].strip()
+        return [_scalar(x.strip()) for x in body.split(",")] if body else []
+    return v
+
+
+def parse_frontmatter_yaml(raw):
+    """Parse the flat YAML subset used in frontmatter. Raises ValueError if the
+    input uses something outside that subset, so callers can report it honestly
+    rather than silently mis-reading a page."""
+    data, key = {}, None
+    for line in raw.split("\n"):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        m_item = re.match(r"^\s+-\s*(.*)$", line)
+        if m_item:
+            if key is None:
+                raise ValueError("list item before any key")
+            data.setdefault(key, [])
+            if not isinstance(data[key], list):
+                raise ValueError(f"list item under non-list key {key!r}")
+            data[key].append(_scalar(m_item.group(1)))
+            continue
+        m_kv = re.match(r"^([A-Za-z_][\w.-]*)\s*:\s*(.*)$", line)
+        if not m_kv:
+            raise ValueError(f"unsupported line: {line[:60]!r}")
+        key, val = m_kv.group(1), m_kv.group(2)
+        if val.strip() in ("|", ">", "|-", ">-"):
+            raise ValueError(f"block scalar on {key!r} is outside the supported subset")
+        data[key] = [] if val.strip() == "" else _scalar(val)
+    return data
+
+
+def load_frontmatter(raw, prefer_pyyaml=True):
+    """Load frontmatter YAML, using PyYAML when available."""
+    if prefer_pyyaml and _yaml is not None:
+        out = _yaml.safe_load(raw)
+        return out if out is not None else {}
+    return parse_frontmatter_yaml(raw)
+
+
+HAVE_PYYAML = _yaml is not None
+
+BASE = "https://wso2.com/api-platform/docs"
+DOCS_ROOT = "en/docs"
+
+VER_RE = re.compile(r"^(\d+\.\d+(\.\d+)?|next|latest)$")
+INDEXY = ("index", "README")
+
+# A *documentation* version segment lives at the top of the tree: either at the
+# docs root (`next/...`) or directly under a single-segment product directory
+# (`api-manager/4.7.0/...`). Anything deeper that merely looks like a version is
+# something else — most importantly a third-party connector's own release
+# directory, e.g.
+#     api-manager/4.2.0/reference/connectors/redis-connector/1.0.1/
+# Treating that as a doc version invents a phantom product and can strip the
+# wrong segment out of a URL, so the depth limit is load-bearing, not cosmetic.
+MAX_VERSION_DEPTH = 1
+
+
+def version_index(rel):
+    """Index of the doc-version segment in `rel`, or None if there isn't one."""
+    parts = rel.split("/")
+    for i, p in enumerate(parts[:MAX_VERSION_DEPTH + 1]):
+        if VER_RE.match(p):
+            return i
+    return None
+
+REQUIRED = ["title", "description", "canonical_url", "md_url", "tags",
+            "author", "last_updated", "content_type"]
+AUTHOR = "WSO2 API Platform Documentation Team"
+DESC_MAX = 158
+DESC_MIN = 50
+TITLE_MAX = 60
+
+# The enum from .claude/rules/doc-frontmatter-and-metadata.md, verbatim.
+ALLOWED_CT = {"how-to", "tutorial", "reference", "concept", "explanation",
+              "troubleshooting", "faq", "release-notes", "changelog", "quickstart"}
+
+# Near-miss values that appear in practice but are not in the rule's enum, mapped
+# onto the closest valid type. `overview` is the common one; it folds into
+# `concept`. Set ADD_OVERVIEW_TO_ENUM to treat it as valid in its own right.
+ADD_OVERVIEW_TO_ENUM = False
+CT_ALIASES = {
+    "overview": "concept",
+    "guide": "how-to",
+    "howto": "how-to",
+    "how to": "how-to",
+    "quick-start": "quickstart",
+    "quick start": "quickstart",
+    "getting-started": "quickstart",
+    "ref": "reference",
+    "conceptual": "concept",
+    "release notes": "release-notes",
+}
+
+
+# Domains the documentation has migrated away from. A link or a frontmatter URL
+# still pointing at one of these is migration debt regardless of which source repo
+# it came from, so add to this list rather than editing the checkers when another
+# set of docs is folded in.
+LEGACY_DOMAINS = (
+    "apim.docs.wso2.com",
+    "/bijira/",
+)
+
+
+def is_legacy_url(value):
+    """True if `value` points at a pre-migration location."""
+    v = str(value)
+    return any(d in v for d in LEGACY_DOMAINS)
+
+
+def effective_allowed_ct():
+    s = set(ALLOWED_CT)
+    if ADD_OVERVIEW_TO_ENUM:
+        s.add("overview")
+    return s
+
+
+def split_version(rel):
+    """Return (version_or_None, path_with_version_removed)."""
+    i = version_index(rel)
+    if i is None:
+        return None, rel
+    parts = rel.split("/")
+    return parts[i], "/".join(parts[:i] + parts[i + 1:])
+
+
+def product_of(rel):
+    """Top-level product directory for a versioned page, else None."""
+    i = version_index(rel)
+    if i is None:
+        return None
+    return "/".join(rel.split("/")[:i])
+
+
+def discover_versions(docs_root=DOCS_ROOT):
+    """Map product dir -> sorted list of on-disk version segments.
+
+    ``next`` sorts last (it is unreleased); numeric versions sort naturally.
+    """
+    found = {}
+    for root, dirs, _ in os.walk(docs_root):
+        prod = os.path.relpath(root, docs_root).replace("\\", "/")
+        if prod == ".":
+            prod = ""
+        # Depth of the version dir itself == number of segments in `prod`.
+        if len(prod.split("/")) > MAX_VERSION_DEPTH if prod else False:
+            continue
+        for d in dirs:
+            if VER_RE.match(d):
+                found.setdefault(prod, set()).add(d)
+
+    def key(v):
+        if v in ("next", "latest"):
+            return (1, [])
+        return (0, [int(x) for x in v.split(".")])
+
+    return {k: sorted(v, key=key) for k, v in found.items()}
+
+
+def current_release(product, versions_map):
+    """Newest *released* version for a product (ignores next/latest)."""
+    vs = [v for v in versions_map.get(product, []) if v not in ("next", "latest")]
+    return vs[-1] if vs else None
+
+
+def site_paths(rel, versions_map=None, policy="latest-only"):
+    """Derive (canonical_url, md_url) for a repo-relative Markdown path.
+
+    policy:
+      "latest-only"  RECOMMENDED. The current release gets the version-less URL;
+                     every other version keeps its version segment. This is the
+                     only policy under which each file owns a unique md_url.
+      "strip-all"    What the repo does today: every version claims the
+                     version-less URL. Produces collisions between versions.
+      "keep-all"     Every version, including the current release, keeps its
+                     segment. Unique, but no stable "latest" URL.
+    """
+    versions_map = versions_map if versions_map is not None else {}
+    ver, stripped = split_version(rel)
+    prod = product_of(rel)
+
+    if ver is None:
+        url_rel = rel
+    elif policy == "strip-all":
+        url_rel = stripped
+    elif policy == "keep-all":
+        url_rel = rel
+    else:  # latest-only
+        url_rel = stripped if ver == current_release(prod, versions_map) else rel
+
+    stem = url_rel[:-3] if url_rel.endswith(".md") else url_rel
+    base = stem.rsplit("/", 1)[-1]
+
+    if base in INDEXY:
+        dir_part = stem[: -len(base)].rstrip("/")
+        canonical = f"{BASE}/{dir_part}/" if dir_part else f"{BASE}/"
+        md = f"{BASE}/{dir_part}.md" if dir_part else f"{BASE}/index.md"
+    else:
+        canonical = f"{BASE}/{stem}/"
+        md = f"{BASE}/{stem}.md"
+    return canonical, md
+
+
+def git_last_modified(path, repo_root="."):
+    """Author date of the last commit touching `path`, as YYYY-MM-DD."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_root, "log", "-1", "--format=%ad", "--date=short", "--", path],
+            capture_output=True, text=True, timeout=30,
+        )
+        d = out.stdout.strip()
+        if re.match(r"^\d{4}-\d{2}-\d{2}$", d):
+            return d
+    except Exception:
+        pass
+    return datetime.date.today().isoformat()
+
+
+def norm_date(v):
+    """Coerce whatever YAML gave us into a YYYY-MM-DD string, or None."""
+    if v is None:
+        return None
+    if isinstance(v, (datetime.date, datetime.datetime)):
+        return v.date().isoformat() if isinstance(v, datetime.datetime) else v.isoformat()
+    s = str(v).strip().strip('"').strip("'").split("T")[0]
+    return s if re.match(r"^\d{4}-\d{2}-\d{2}$", s) else None
+
+
+def split_frontmatter(text):
+    """Return (raw_yaml_or_None, body). Tolerates a UTF-8 BOM."""
+    t = text.lstrip("﻿")
+    if not t.startswith("---"):
+        return None, t
+    m = re.match(r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*\r?\n?(.*)$", t, re.S)
+    if not m:
+        return None, t
+    return m.group(1), m.group(2)
+
+
+def first_h1(body):
+    """First H1, with inline Markdown stripped.
+
+    Legacy API Manager pages write headings as `# **Bold Heading**`, and the
+    emphasis markers must not leak into `title` — they would be rendered
+    literally in a browser tab and a search result.
+    """
+    m = re.search(r"^#\s+(.+?)\s*$", body, re.M)
+    if not m:
+        return None
+    t = m.group(1).strip()
+    t = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", t)   # links -> link text
+    t = re.sub(r"`([^`]*)`", r"\1", t)                   # code spans
+    t = re.sub(r"\*\*([^*]+)\*\*", r"\1", t)            # bold
+    t = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", t)      # underscore emphasis
+    t = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"\1", t)   # single-asterisk italics
+    t = re.sub(r"<[^>]+>", "", t)                        # stray inline HTML
+    t = re.sub(r"\{#[\w-]+\}", "", t)                    # explicit anchor id
+    return re.sub(r"\s+", " ", t).strip() or None
+
+
+def md_files(docs_root=DOCS_ROOT):
+    out = []
+    for root, _, fs in os.walk(docs_root):
+        for f in fs:
+            if f.endswith(".md"):
+                out.append(os.path.relpath(os.path.join(root, f), docs_root).replace("\\", "/"))
+    return sorted(out)
+
+
+def yaml_str(s):
+    """Quote a scalar for YAML only when it needs it."""
+    s = str(s)
+    if re.search(r'^[\s>|@`%&*!\[\]{}#-]|[:#]\s|["\']|\n|:$', s) or s.strip() != s:
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+# The repo's house style: these scalars are double-quoted, everything else is bare.
+# Matching it exactly keeps a fix run's diff limited to fields that genuinely
+# changed, instead of showing a change on every page it touches.
+ALWAYS_QUOTE = {"title", "description", "content_type"}
+NEVER_QUOTE = {"canonical_url", "md_url", "last_updated", "author"}
+
+
+def render_frontmatter(fm, order=None):
+    """Serialise a frontmatter dict in the repo's conventional field order and quoting."""
+    order = order or REQUIRED
+    keys = [k for k in order if k in fm] + [k for k in fm if k not in order]
+    lines = ["---"]
+    for k in keys:
+        v = fm[k]
+        if isinstance(v, list):
+            lines.append(f"{k}:")
+            for item in v:
+                lines.append(f"  - {yaml_str(item)}")
+        elif k in NEVER_QUOTE:
+            lines.append(f"{k}: {v}")
+        elif k in ALWAYS_QUOTE:
+            esc = str(v).replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'{k}: "{esc}"')
+        else:
+            lines.append(f"{k}: {yaml_str(v)}")
+    lines.append("---")
+    return "\n".join(lines)

--- a/.claude/skills/wso2-doc-frontmatter/scripts/report_links.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/report_links.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Turn raw broken-link findings into a fix plan a person or an agent can act on.
+
+    python3 scripts/report_links.py en/docs --out BROKEN-LINKS.md
+    python3 scripts/report_links.py en/docs --scope <product>/<version> --out BROKEN-LINKS-<version>.md
+
+`check_links.py` answers "what is broken". This answers "what do I change", which
+is a different question and the one that actually gets the work done. Every
+finding is classified by *cause*, because the causes have completely different
+fixes:
+
+  * wrong relative depth  -> exact mechanical rewrite, no judgement at all
+  * renamed / moved page  -> a target exists elsewhere; propose it, rank confidence
+  * genuinely gone        -> needs a human decision, cannot be automated
+  * pre-migration domain  -> map to the new site or drop the link
+  * missing anchor        -> heading was reworded
+
+The report ends with a prompt written for an AI coding agent, so the mechanical
+tiers can be handed straight off.
+"""
+import os
+import re
+import sys
+import json
+import argparse
+import collections
+import urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from fm_lib import split_version, is_legacy_url  # noqa: E402
+
+LINK = re.compile(r'(!?)\[([^\]]*)\]\(\s*<?([^)\s>]+)>?(?:\s+"[^"]*")?\s*\)')
+HTML_SRC = re.compile(r'<(?:img|a)[^>]+(?:src|href)="([^"]+)"')
+
+
+def version_root(rel):
+    """`<product>/<version>/a/b.md` -> `<product>/<version>`, else ''."""
+    ver, _ = split_version(rel)
+    if not ver:
+        return ""
+    parts = rel.split("/")
+    return "/".join(parts[: parts.index(ver) + 1])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("docs_root", nargs="?", default="en/docs")
+    ap.add_argument("--scope", default=None,
+                    help="Only report files under this path prefix, e.g. <product>/<version>")
+    ap.add_argument("--out", default="BROKEN-LINKS.md")
+    ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--max-rows", type=int, default=40,
+                    help="Rows per table in the Markdown before truncating (JSON is always complete).")
+    args = ap.parse_args()
+
+    root = args.docs_root.rstrip("/")
+
+    all_files, md_list = set(), []
+    for r, _, fs in os.walk(root):
+        for f in fs:
+            rel = os.path.relpath(os.path.join(r, f), root).replace("\\", "/")
+            all_files.add(rel)
+            if f.endswith(".md"):
+                md_list.append(rel)
+    md_list.sort()
+
+    by_basename = collections.defaultdict(list)
+    for f in all_files:
+        by_basename[os.path.basename(f)].append(f)
+
+    def resolves(cand):
+        return any(c in all_files
+                   for c in (cand, cand + ".md", cand + "/index.md", cand + "/README.md"))
+
+    def slug(h):
+        h = re.sub(r"`|\*", "", h)
+        h = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", h)
+        h = re.sub(r"<[^>]+>", "", h)
+        h = re.sub(r"[^\w\s-]", "", h).strip().lower()
+        return re.sub(r"[-\s]+", "-", h)
+
+    anchors = {}
+    for p in md_list:
+        txt = open(os.path.join(root, p), encoding="utf-8", errors="replace").read()
+        txt = re.sub(r"<!--.*?-->", "", txt, flags=re.S)
+        txt = re.sub(r"```.*?```", "", txt, flags=re.S)
+        a = set()
+        for m in re.finditer(r"^#{1,6}\s+(.+?)\s*$", txt, re.M):
+            h = m.group(1)
+            exp = re.search(r"\{#([\w-]+)\}", h)
+            if exp:
+                a.add(exp.group(1))
+                h = h[: exp.start()]
+            a.add(slug(h))
+        for m in re.finditer(r'<a[^>]+(?:name|id)="([^"]+)"', txt):
+            a.add(m.group(1))
+        anchors[p] = a
+
+    tiers = {k: [] for k in ("templated", "malformed", "depth", "renamed", "gone",
+                             "stale", "anchor")}
+
+    targets = [p for p in md_list if not args.scope or p.startswith(args.scope)]
+    for p in targets:
+        txt = open(os.path.join(root, p), encoding="utf-8", errors="replace").read()
+        body = re.sub(r"<!--.*?-->", "", txt, flags=re.S)
+        body = re.sub(r"```.*?```", "", body, flags=re.S)
+        d = os.path.dirname(p)
+        stem = os.path.basename(p)[:-3]
+        vroot = version_root(p)
+
+        raw = [(m.group(1) == "!", m.group(3)) for m in LINK.finditer(body)]
+        raw += [(False, m.group(1)) for m in HTML_SRC.finditer(body)]
+
+        for is_img, t in raw:
+            if t.startswith(("mailto:", "tel:", "//", "#!")):
+                continue
+
+            # Malformed syntax, caught before resolution so it isn't mis-filed as a
+            # missing target. Both forms below occur in migrated pages and both
+            # render as literal broken text, so the fix is exact.
+            # A target containing a template variable (e.g. `{{base_path}}`) is not
+            # a path — it is expanded at build time by machinery the target site may
+            # not have. Resolving it statically is meaningless and any "fix" derived
+            # from it is a guess. Report and move on; never propose a replacement.
+            if re.search(r"\{\{.*?\}\}", t):
+                tiers["templated"].append({"file": p, "link": t,
+                                           "variable": ", ".join(sorted(set(
+                                               re.findall(r"\{\{.*?\}\}", t))))})
+                continue
+
+            raw_t = t
+            cleaned = t.strip("`'\"")                       # [text](`https://…`)
+            m_hash = re.match(r"^(#{2,})([\w-]+)$", cleaned)  # [text](###anchor)
+            if m_hash:
+                tiers["malformed"].append({
+                    "file": p, "link": raw_t, "suggested": "#" + m_hash.group(2),
+                    "why": f"{len(m_hash.group(1))} `#` characters; an anchor takes exactly one"})
+                continue
+            if cleaned != raw_t:
+                tiers["malformed"].append({
+                    "file": p, "link": raw_t, "suggested": cleaned,
+                    "why": "target is wrapped in backticks or quotes, so it is not a valid URL"})
+                continue
+            if is_legacy_url(t):
+                tiers["stale"].append({"file": p, "link": t})
+                continue
+            if re.match(r"^https?://", t):
+                continue
+
+            path, _, frag = t.partition("#")
+            path = urllib.parse.unquote(path)
+            frag = urllib.parse.unquote(frag)
+
+            if not path:
+                if frag and frag not in anchors.get(p, set()):
+                    tiers["anchor"].append({"file": p, "link": t, "target_file": p, "anchor": frag})
+                continue
+
+            src_rel = os.path.normpath(os.path.join(d, path)).replace("\\", "/")
+            if resolves(src_rel):
+                if frag:
+                    tf = next((c for c in (src_rel, src_rel + ".md", src_rel + "/index.md",
+                                           src_rel + "/README.md") if c in all_files), None)
+                    if tf and tf.endswith(".md") and frag not in anchors.get(tf, set()):
+                        tiers["anchor"].append({"file": p, "link": t, "target_file": tf, "anchor": frag})
+                continue
+
+            # Directory-URL semantics: the rendered page sits one level deeper
+            # than the source file, so a link written against the *URL* needs one
+            # fewer `../` to be correct against the source.
+            url_rel = os.path.normpath(os.path.join(d, stem, path)).replace("\\", "/")
+            if resolves(url_rel):
+                fixed = os.path.relpath(url_rel, d).replace("\\", "/")
+                if url_rel + ".md" in all_files:
+                    fixed += ".md"
+                tiers["depth"].append({"file": p, "link": t, "resolves_to": url_rel,
+                                       "suggested": fixed + (("#" + frag) if frag else "")})
+                continue
+
+            # Nothing resolves. Look for a file of the same name elsewhere — the
+            # restructure renamed directories without updating links, so the page
+            # usually still exists somewhere under the same version root.
+            base = os.path.basename(path.rstrip("/")) or stem
+            cands = by_basename.get(base + ".md", []) + by_basename.get(base, [])
+            if vroot:
+                # STRICT. Previously this fell back to the unscoped candidate list
+                # when nothing matched inside the version, which proposed targets in
+                # *other* versions — sending a reader from a current page to an old
+                # release. A missing page inside this version is `gone`, not a reason
+                # to look in another version.
+                cands = [c for c in cands if c.startswith(vroot + "/")]
+            cands = [c for c in cands if c != p]
+
+            if len(cands) == 1:
+                sug = os.path.relpath(cands[0], d).replace("\\", "/")
+                tiers["renamed"].append({"file": p, "link": t, "found_at": cands[0],
+                                         "suggested": sug + (("#" + frag) if frag else ""),
+                                         "confidence": "high"})
+            elif 2 <= len(cands) <= 5:
+                ranked = sorted(cands, key=lambda c: -len(os.path.commonprefix([c, p])))
+                sug = os.path.relpath(ranked[0], d).replace("\\", "/")
+                tiers["renamed"].append({"file": p, "link": t, "found_at": ranked[0],
+                                         "suggested": sug + (("#" + frag) if frag else ""),
+                                         "confidence": f"low ({len(cands)} candidates)",
+                                         "alternatives": ranked[:5]})
+            elif cands:
+                # A generic basename like `overview.md` matches dozens of pages.
+                # Guessing one would be worse than saying nothing: a guess reads as
+                # an answer, and nobody re-checks an answer. List the field instead.
+                ranked = sorted(cands, key=lambda c: -len(os.path.commonprefix([c, p])))
+                tiers["gone"].append({"file": p, "link": t,
+                                      "kind": "image" if is_img else "link",
+                                      "note": f"{len(cands)} files share this name — too ambiguous to propose one",
+                                      "candidates": ranked[:6]})
+            else:
+                tiers["gone"].append({"file": p, "link": t,
+                                      "kind": "image" if is_img else "link",
+                                      "note": "no file of this name exists anywhere under the docs root"})
+
+    # ---------------- write the report ----------------
+    n = {k: len(v) for k, v in tiers.items()}
+    total = sum(n.values())
+    scope_label = args.scope or f"all of {root}"
+    auto = (n["malformed"] + n["depth"]
+            + len([x for x in tiers["renamed"] if x["confidence"] == "high"]))
+
+    L = []
+    w = L.append
+    w(f"# Broken links and images — `{scope_label}`")
+    w("")
+    w(f"**{total} findings** across {len(targets)} pages. "
+      f"**{auto}** have an exact or high-confidence mechanical fix; "
+      f"**{n['gone']}** need a human decision.")
+    w("")
+    w("| Tier | Cause | Count | Fixable how |")
+    w("|---|---|---|---|")
+    w(f"| — | Contains a template variable | {n['templated']} | **Leave alone** — pending the redirect decision |")
+    w(f"| 0 | Malformed link syntax | {n['malformed']} | Exact rewrite — no judgement |")
+    w(f"| 1 | Wrong relative depth | {n['depth']} | Exact rewrite — no judgement |")
+    w(f"| 2 | Renamed or moved target | {n['renamed']} | Proposed target, check confidence |")
+    w(f"| 3 | Pre-migration domain | {n['stale']} | Map to new site, or drop |")
+    w(f"| 4 | Missing anchor | {n['anchor']} | Heading was reworded |")
+    w(f"| 5 | No target anywhere | {n['gone']} | Human decision — cannot automate |")
+    w("")
+    w("Work the tiers in order. Tier 1 is safe to apply in bulk; tier 5 is the only "
+      "one that needs someone who knows what the page was supposed to say.")
+    w("")
+
+    def table(rows, cols, keys, limit):
+        w("| " + " | ".join(cols) + " |")
+        w("|" + "|".join(["---"] * len(cols)) + "|")
+        for r in rows[:limit]:
+            w("| " + " | ".join(f"`{r.get(k,'')}`" if k != "confidence" else str(r.get(k, ""))
+                                for k in keys) + " |")
+        if len(rows) > limit:
+            w("")
+            w(f"_…and {len(rows) - limit} more. Full list in the JSON sidecar._")
+        w("")
+
+    if n["templated"]:
+        w("## Excluded — links containing a template variable")
+        w("")
+        w("These targets contain a build-time variable such as `{{base_path}}`. They are "
+          "not paths, so there is nothing to resolve and no fix to derive — any suggestion "
+          "would be invented. **Do not rewrite them.** How these are migrated depends on "
+          "the redirect strategy, which is a separate decision; until that is settled they "
+          "are out of scope for link fixing.")
+        w("")
+        table(tiers["templated"], ["Page", "Link", "Variable"],
+              ["file", "link", "variable"], args.max_rows)
+
+    if n["malformed"]:
+        w("## Tier 0 — Malformed link syntax")
+        w("")
+        w("The link target is not a valid path or URL, so it renders as literal broken text "
+          "regardless of whether the destination exists. Carried over from the old wiki. "
+          "The replacement is exact.")
+        w("")
+        table(tiers["malformed"], ["Page", "Currently", "Change to", "Why"],
+              ["file", "link", "suggested", "why"], args.max_rows)
+
+    if n["depth"]:
+        w("## Tier 1 — Wrong relative depth")
+        w("")
+        w("The target exists; the path has one `../` too many. These render correctly in a "
+          "browser (the published URL sits one directory deeper than the source file), so they "
+          "look fine on the site — but `mkdocs build` warns about every one, and anyone reading "
+          "the raw Markdown through `md_url` gets a broken path. The replacement below is exact.")
+        w("")
+        table(tiers["depth"], ["Page", "Currently", "Change to"],
+              ["file", "link", "suggested"], args.max_rows)
+
+    if n["renamed"]:
+        hi = [x for x in tiers["renamed"] if x["confidence"] == "high"]
+        lo = [x for x in tiers["renamed"] if x["confidence"] != "high"]
+        w("## Tier 2 — Renamed or moved target")
+        w("")
+        w("The target does not exist at the path written, but a file of the same name exists "
+          "elsewhere under the same version. This is the restructure: directories were renamed "
+          "and the inbound links were never updated.")
+        w("")
+        if hi:
+            w(f"### Exactly one candidate — high confidence ({len(hi)})")
+            w("")
+            table(hi, ["Page", "Currently", "Change to"], ["file", "link", "suggested"], args.max_rows)
+        if lo:
+            w(f"### Several candidates — verify before applying ({len(lo)})")
+            w("")
+            table(lo, ["Page", "Currently", "Best guess", "Confidence"],
+                  ["file", "link", "suggested", "confidence"], args.max_rows)
+
+    if n["stale"]:
+        w("## Tier 3 — Links to the pre-migration site")
+        w("")
+        w("These point at a location the documentation has migrated away from. For each "
+          "one: find the equivalent page on the new site and link to it relatively, or if the "
+          "content wasn't migrated, remove the link and say so in the prose. Never leave a "
+          "reader on the old site.")
+        w("")
+        table(tiers["stale"], ["Page", "Link"], ["file", "link"], args.max_rows)
+
+    if n["anchor"]:
+        w("## Tier 4 — Missing anchor")
+        w("")
+        w("The page resolves but the `#fragment` matches no heading, so the reader lands at the "
+          "top instead of the section. Usually the heading was reworded. Open the target, find "
+          "the heading that was meant, and use its current slug.")
+        w("")
+        table(tiers["anchor"], ["Page", "Link", "Target file", "Missing anchor"],
+              ["file", "link", "target_file", "anchor"], args.max_rows)
+
+    if n["gone"]:
+        w("## Tier 5 — No target anywhere")
+        w("")
+        w("No file of this name exists anywhere under the docs root, so there is nothing to "
+          "point at. Each needs a decision: was the page meant to be migrated and missed, was it "
+          "deliberately dropped (then the link and its sentence should go), or was it merged into "
+          "another page (then link there)? **Do not guess these.**")
+        w("")
+        table(tiers["gone"], ["Page", "Broken target", "Note"],
+              ["file", "link", "note"], args.max_rows)
+
+    # ---- the agent prompt ----
+    w("---")
+    w("")
+    w("## Prompt for an AI coding agent")
+    w("")
+    w("Paste the block below to an agent working in the repo root. It is deliberately scoped to "
+      "tiers 1 and 2-high — the tiers with a defensible mechanical answer. Tiers 3 to 5 need "
+      "judgement and are left out on purpose.")
+    w("")
+    w("````text")
+    w(f"You are fixing broken links in the WSO2 API Platform docs, scope: {scope_label}.")
+    w("")
+    w(f"Read the fix plan in `{args.out}`" +
+      (f" and the machine-readable list in `{args.json_out}`." if args.json_out else "."))
+    w("")
+    w("Apply ONLY these tiers:")
+    w("  - Tier 0 (Malformed link syntax): apply every row exactly as given.")
+    w("  - Tier 1 (Wrong relative depth): apply every row exactly as given.")
+    w("  - Tier 2, high-confidence subsection only: apply every row as given.")
+    w("")
+    w("Rules:")
+    w("  1. Replace only the link target inside the parentheses. Never change the link TEXT,")
+    w("     the surrounding sentence, or anything else on the line.")
+    w("  2. A target may appear more than once in a file — replace every occurrence of that")
+    w("     exact target in that file.")
+    w("  3. Preserve any `#fragment` already on the link unless the plan says otherwise.")
+    w("  4. Do NOT touch tiers 3, 4, or 5, and do NOT touch anything in the")
+    w("     \"Contains a template variable\" section. Do not invent a target that is")
+    w("     not in the plan.")
+    w("  5. Do not reformat, reflow, or reorder anything. Minimal diffs only.")
+    w("")
+    w("Verify when done, from the repo root:")
+    w(f"  python3 .claude/skills/wso2-doc-frontmatter/scripts/check_links.py {root}" +
+      (f" --json /tmp/after.json" if True else ""))
+    w("")
+    w("The blocking count must go DOWN and no new codes may appear. If any count rises, stop")
+    w("and report what you changed rather than continuing.")
+    w("")
+    w("Then report: rows applied per tier, files touched, and the before/after blocking counts.")
+    w("````")
+    w("")
+    w("### Why tiers 3 to 5 are excluded")
+    w("")
+    w("Each needs information that isn't in the repo: which new page replaces an old-site link, "
+      "which reworded heading was meant, whether a missing page was dropped on purpose. An agent "
+      "asked to fix those will produce plausible links to the wrong places, which is worse than "
+      "a visibly broken link because nobody re-checks it.")
+    w("")
+    w("Template-variable links are excluded for a different reason: they are not broken at all "
+      "in their original context. They depend on a build-time substitution, and whether that "
+      "survives migration is a redirect-strategy decision, not a link fix.")
+
+    open(args.out, "w", encoding="utf-8").write("\n".join(L) + "\n")
+
+    if args.json_out:
+        json.dump({"scope": args.scope, "docs_root": root, "counts": n, "tiers": tiers},
+                  open(args.json_out, "w"), indent=1)
+
+    print(f"{total} findings across {len(targets)} pages "
+          f"({auto} mechanically fixable, {n['gone']} need a human)")
+    for k in ("templated", "malformed", "depth", "renamed", "stale", "anchor", "gone"):
+        print(f"  {n[k]:5d}  {k}")
+    print(f"\nreport -> {args.out}")
+    if args.json_out:
+        print(f"json   -> {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wso2-doc-frontmatter/scripts/report_links.py
+++ b/.claude/skills/wso2-doc-frontmatter/scripts/report_links.py
@@ -96,8 +96,8 @@ def main():
             a.add(m.group(1))
         anchors[p] = a
 
-    tiers = {k: [] for k in ("templated", "malformed", "depth", "renamed", "gone",
-                             "stale", "anchor")}
+    tiers = {k: [] for k in ("templated_fixable", "templated", "malformed", "depth",
+                             "renamed", "gone", "stale", "anchor")}
 
     targets = [p for p in md_list if not args.scope or p.startswith(args.scope)]
     for p in targets:
@@ -118,14 +118,35 @@ def main():
             # Malformed syntax, caught before resolution so it isn't mis-filed as a
             # missing target. Both forms below occur in migrated pages and both
             # render as literal broken text, so the fix is exact.
-            # A target containing a template variable (e.g. `{{base_path}}`) is not
-            # a path — it is expanded at build time by machinery the target site may
-            # not have. Resolving it statically is meaningless and any "fix" derived
-            # from it is a guess. Report and move on; never propose a replacement.
+            # `{{base_path}}` stands for the root of the version's site, so the
+            # remainder is a path relative to that version's directory. Where the
+            # resource actually exists there, the link can be rewritten as an
+            # ordinary relative path and the variable dropped — that is a real fix,
+            # not a guess. Where it does not exist, the target may be served by a
+            # redirect, so leave it alone until the redirect strategy is settled.
             if re.search(r"\{\{.*?\}\}", t):
-                tiers["templated"].append({"file": p, "link": t,
-                                           "variable": ", ".join(sorted(set(
-                                               re.findall(r"\{\{.*?\}\}", t))))})
+                m_bp = re.match(r"^\{\{\s*base_path\s*\}\}/?(.*)$", t)
+                fixed = None
+                if m_bp:
+                    rest, _, bfrag = m_bp.group(1).partition("#")
+                    rest = urllib.parse.unquote(rest).strip("/")
+                    base_dir = vroot if vroot else ""
+                    cand = f"{base_dir}/{rest}" if base_dir else rest
+                    cand = os.path.normpath(cand).replace("\\", "/")
+                    target = next((c for c in (cand, cand + ".md", cand + "/index.md",
+                                               cand + "/README.md") if c in all_files), None)
+                    if target:
+                        fixed = os.path.relpath(target, d).replace("\\", "/")
+                        if bfrag:
+                            fixed += "#" + bfrag
+                if fixed:
+                    tiers["templated_fixable"].append({
+                        "file": p, "link": t, "suggested": fixed,
+                        "why": "resource exists, so the variable can be replaced with a relative path"})
+                else:
+                    tiers["templated"].append({"file": p, "link": t,
+                                               "variable": ", ".join(sorted(set(
+                                                   re.findall(r"\{\{.*?\}\}", t))))})
                 continue
 
             raw_t = t
@@ -221,7 +242,7 @@ def main():
     n = {k: len(v) for k, v in tiers.items()}
     total = sum(n.values())
     scope_label = args.scope or f"all of {root}"
-    auto = (n["malformed"] + n["depth"]
+    auto = (n["templated_fixable"] + n["malformed"] + n["depth"]
             + len([x for x in tiers["renamed"] if x["confidence"] == "high"]))
 
     L = []
@@ -234,7 +255,8 @@ def main():
     w("")
     w("| Tier | Cause | Count | Fixable how |")
     w("|---|---|---|---|")
-    w(f"| — | Contains a template variable | {n['templated']} | **Leave alone** — pending the redirect decision |")
+    w(f"| 0 | `{{{{base_path}}}}` where the resource exists | {n['templated_fixable']} | Exact rewrite to a relative path |")
+    w(f"| — | `{{{{base_path}}}}` where it does not | {n['templated']} | **Leave alone** — may be a redirect |")
     w(f"| 0 | Malformed link syntax | {n['malformed']} | Exact rewrite — no judgement |")
     w(f"| 1 | Wrong relative depth | {n['depth']} | Exact rewrite — no judgement |")
     w(f"| 2 | Renamed or moved target | {n['renamed']} | Proposed target, check confidence |")
@@ -257,14 +279,23 @@ def main():
             w(f"_…and {len(rows) - limit} more. Full list in the JSON sidecar._")
         w("")
 
-    if n["templated"]:
-        w("## Excluded — links containing a template variable")
+    if n["templated_fixable"]:
+        w("## Tier 0 — `{{base_path}}` where the resource exists")
         w("")
-        w("These targets contain a build-time variable such as `{{base_path}}`. They are "
-          "not paths, so there is nothing to resolve and no fix to derive — any suggestion "
-          "would be invented. **Do not rewrite them.** How these are migrated depends on "
-          "the redirect strategy, which is a separate decision; until that is settled they "
-          "are out of scope for link fixing.")
+        w("`{{base_path}}` stands for the root of the version's site, so the rest of the "
+          "target is a path within that version's directory. For these, the resource is "
+          "there: the variable can be dropped and the link written as an ordinary relative "
+          "path. The replacement below is exact.")
+        w("")
+        table(tiers["templated_fixable"], ["Page", "Currently", "Change to"],
+              ["file", "link", "suggested"], args.max_rows)
+
+    if n["templated"]:
+        w("## Excluded — `{{base_path}}` where the resource does not exist")
+        w("")
+        w("Same variable, but the target is not present at that path in this version. It may "
+          "be served by a redirect, or the page may not have been migrated. **Leave these "
+          "alone** until the redirect strategy is settled — a rewrite here would be a guess.")
         w("")
         table(tiers["templated"], ["Page", "Link", "Variable"],
               ["file", "link", "variable"], args.max_rows)
@@ -356,6 +387,7 @@ def main():
       (f" and the machine-readable list in `{args.json_out}`." if args.json_out else "."))
     w("")
     w("Apply ONLY these tiers:")
+    w("  - Tier 0 (`{{base_path}}` where the resource exists): apply every row as given.")
     w("  - Tier 0 (Malformed link syntax): apply every row exactly as given.")
     w("  - Tier 1 (Wrong relative depth): apply every row exactly as given.")
     w("  - Tier 2, high-confidence subsection only: apply every row as given.")
@@ -367,8 +399,8 @@ def main():
     w("     exact target in that file.")
     w("  3. Preserve any `#fragment` already on the link unless the plan says otherwise.")
     w("  4. Do NOT touch tiers 3, 4, or 5, and do NOT touch anything in the")
-    w("     \"Contains a template variable\" section. Do not invent a target that is")
-    w("     not in the plan.")
+    w("     \"`{{base_path}}` where the resource does not exist\" section. Do not")
+    w("     invent a target that is not in the plan.")
     w("  5. Do not reformat, reflow, or reorder anything. Minimal diffs only.")
     w("")
     w("Verify when done, from the repo root:")
@@ -400,7 +432,8 @@ def main():
 
     print(f"{total} findings across {len(targets)} pages "
           f"({auto} mechanically fixable, {n['gone']} need a human)")
-    for k in ("templated", "malformed", "depth", "renamed", "stale", "anchor", "gone"):
+    for k in ("templated_fixable", "templated", "malformed", "depth", "renamed",
+              "stale", "anchor", "gone"):
         print(f"  {n[k]:5d}  {k}")
     print(f"\nreport -> {args.out}")
     if args.json_out:

--- a/README.md
+++ b/README.md
@@ -307,3 +307,76 @@ The spell checking and link validation are optional. You can still build and ser
 
 **Python version issues:**
 This project requires Python 3.12. Check your version with `python3 --version`
+
+## Documentation validation skill
+
+This repository ships a Claude skill at `.claude/skills/wso2-doc-frontmatter/` that
+writes and validates page frontmatter, and reports broken links and images. Claude
+Code and Cowork discover it automatically when you open the repo — there is nothing
+to install, and the scripts need only Python 3.8+ with no third-party packages.
+
+It works on any part of the docs. Everywhere below, `<scope>` is a path under
+`en/docs/` — a whole product, a single version, or one section within a version.
+
+### Using it through Claude
+
+From the repository root, name the scope you are working on:
+
+> Use the wso2-doc-frontmatter skill on `<scope>`. Write the frontmatter for every
+> page that needs it, and put the broken links in a separate report with fixes and
+> an agent prompt.
+
+Frontmatter is written in place. Link breakage goes into its own report file, so the
+two can be reviewed, assigned, and merged separately.
+
+### Running the checks directly
+
+The checkers are plain Python and modify nothing, so they are safe to run at any
+time. Each takes `--json <path>` for the full findings list and `--gate` to exit
+non-zero when there is a blocking issue, which is what makes them usable in CI.
+
+```bash
+SK=.claude/skills/wso2-doc-frontmatter/scripts
+
+python3 $SK/fm_audit.py en/docs                        # frontmatter fields
+python3 $SK/check_links.py en/docs                     # links, images, anchors
+python3 $SK/check_redirects.py en/mkdocs.yml en/docs   # redirects vs canonical_url
+python3 $SK/check_style.py en/docs                     # mechanical style rules
+```
+
+Add `--files <paths…>` to narrow the frontmatter audit to the pages a pull request
+touches.
+
+### Writing frontmatter
+
+Always inspect before writing. `--dry-run` is the default, so nothing changes until
+you pass `--apply`, and `git checkout -- en/docs` undoes a run.
+
+```bash
+# Inspect first. Add --files <paths…> to limit the run to one scope.
+python3 $SK/fm_fix.py en/docs --dry-run
+
+# Write it, creating a block on pages that have none.
+python3 $SK/fm_fix.py en/docs --scaffold --apply --worklist work.json
+
+# Apply the title/description/content_type values decided after reading the pages.
+python3 $SK/fm_fix.py en/docs --fill filled.json --apply
+```
+
+The scripts fill in everything derivable from the page's path, its first heading,
+and git history. They deliberately do not invent `title` or `description` — those
+are what a reader and a search engine actually see, and a generated one looks
+finished so nobody revisits it. Those come back in `work.json` for you or Claude to
+write after reading the page.
+
+### Generating a link fix plan
+
+```bash
+python3 $SK/report_links.py en/docs --scope <scope> --out BROKEN-LINKS-<scope>.md
+```
+
+Name the report after its scope; a single repo-wide report goes stale immediately
+and nobody can tell which parts are theirs. The report groups findings by cause,
+proposes an exact replacement where one exists, separates the tiers that need a
+human decision, and ends with a prompt scoped to only the tiers that are safe to
+automate.


### PR DESCRIPTION
## Purpose
Adds tooling to write and validate page frontmatter and to report broken links, so the
derivable fields are derived the same way for every version instead of by hand.

Supports #649.

## Checklist
- [ ] N/A — `llms.txt` update. No documentation pages added.
- [ ] N/A — Image alt text. No images added.
- [ ] N/A — Frontmatter. Tooling only; no doc pages change.

## Goals
Derive `canonical_url` and `md_url` correctly across the multi-version layout, make
frontmatter and link problems countable with a severity, and check for broken links.

## Approach
Four read-only checkers, one fixer, and a shared library. Plain Python, no dependencies.

## User stories
A writer migrating a version adds correct frontmatter without hand-deriving URLs, and gets
a separate list of broken links in their scope. A reviewer can validate a PR's changed
files with one command.

## Release note
N/A — internal tooling.

## Documentation
`README.md` — new "Documentation validation skill" section. Skill docs in
`.claude/skills/wso2-doc-frontmatter/`.

## Training
N/A.

## Certification
N/A — internal tooling.

## Marketing
N/A.

## Automation tests
- Unit tests
  > None
- Integration tests
  > None

## Security checks
- Secure coding standards: yes. Checkers are read-only. The fixer defaults to a dry run,
  needs `--apply` to write, and writes only inside the given docs root. No network access.
- FindSecurityBugs: N/A — Java tool; this is Python.
- No keys, passwords, tokens, usernames, or secrets: yes.

## Migrations (if applicable)
N/A.
