### PR TITLE
[API Portal] Correct the end to end setup doc

### DIFF
--- a/en/docs/next/api-portal/setting-up/design-mode.md
+++ b/en/docs/next/api-portal/setting-up/design-mode.md
@@ -9,7 +9,7 @@ tags:
   - theming
   - design-mode
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-24
+last_updated: 2026-08-05
 content_type: "how-to"
 ---
 
@@ -44,10 +44,10 @@ applications_path = "./samples/applications.yaml"
 
 The sample paths are relative to the app's working directory, where the bundled `samples/` already lives—leave them as they are unless you're pointing at your own sample set.
 
-Then start the portal normally:
+Then restart the API Portal:
 
 ```bash
-npm start
+docker compose restart api-portal
 ```
 
 Visit `http://localhost:9543/api-portal/views/default`.
@@ -211,11 +211,17 @@ Design mode turns off everything that needs a database or an identity provider:
 
 ## Turning design mode off
 
-Set `enabled = false` (or remove the section entirely) and restart:
+Set `enabled = false` (or remove the section entirely) in `configs/config.toml`:
 
 ```toml
 [api_portal.design_mode]
 enabled = false
+```
+
+Then restart:
+
+```bash
+docker compose restart api-portal
 ```
 
 The portal returns to production mode, requiring a database and (if configured) an IDP.

--- a/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
+++ b/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
@@ -42,7 +42,7 @@ The API Portal distribution ships the Platform API alongside it, so one compose 
 ```bash
 curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc3/wso2apip-api-portal-1.0.0-rc3.zip
 unzip wso2apip-api-portal-1.0.0-rc3.zip
-cd wso2apip-api-portal-1.0.0-rc3
+cd wso2apip-api-portal-1.0.0
 ./scripts/setup.sh
 docker compose up -d
 ```
@@ -148,7 +148,7 @@ curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/webhook-subscribers 
 The Platform API's webhook receiver ships disabled, and the shipped `configs/config.toml` has no `[platform_api.webhook]` section wiring in a secret—setting `APIP_CP_WEBHOOK_SECRET` alone does nothing. Enable the receiver and point it at the same secret, then set the value in `api-platform.env` and restart the Platform API so both changes take effect:
 
 ```bash
-cd ../wso2apip-api-portal-1.0.0-rc3
+cd ../wso2apip-api-portal-1.0.0
 
 cat >> configs/config.toml <<'EOF'
 

--- a/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
+++ b/en/docs/next/api-portal/tutorials/secured-api-end-to-end.md
@@ -9,7 +9,7 @@ tags:
   - tutorials
   - authentication
 author: WSO2 API Platform Documentation Team
-last_updated: 2026-07-31
+last_updated: 2026-08-05
 content_type: "tutorial"
 ---
 
@@ -33,7 +33,7 @@ API Portal  ──signed webhook──▶  Platform API  ──control plane─�
 ## Prerequisites
 
 - Docker with the Compose plugin, `curl`, `unzip`, `jq`, and `openssl`
-- Free ports: **9543** (portal), **9243** (Platform API), **9090** and **9094** (gateway management and admin), **8081** (gateway API listener)
+- Free ports: **9543** (portal), **9243** (Platform API), **9090** and **9094** (gateway management and admin), **8080** (gateway API listener)
 
 ## Step 1: Start the control plane and portal
 
@@ -42,7 +42,7 @@ The API Portal distribution ships the Platform API alongside it, so one compose 
 ```bash
 curl -sLO https://github.com/wso2/api-platform/releases/download/api-portal%2Fv1.0.0-rc3/wso2apip-api-portal-1.0.0-rc3.zip
 unzip wso2apip-api-portal-1.0.0-rc3.zip
-cd wso2apip-api-portal-1.0.0
+cd wso2apip-api-portal-1.0.0-rc3
 ./scripts/setup.sh
 docker compose up -d
 ```
@@ -67,7 +67,7 @@ export TOKEN=$(curl -sk -X POST https://localhost:9243/api/portal/v0.9/auth/logi
 
 export PROJECT_ID=$(curl -sk -X POST https://localhost:9243/api/v0.9/projects \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{"id":"e2e","displayName":"e2e","description":"End-to-end tutorial"}' | jq -r .id)
+  -d '{"id":"my-project","displayName":"My Project","description":"My tutorial project"}' | jq -r .id)
 
 echo "project: $PROJECT_ID"
 ```
@@ -77,11 +77,11 @@ echo "project: $PROJECT_ID"
 A gateway has to be registered with the Platform API before it can join. Registration returns an id; a second call mints the token the gateway authenticates with.
 
 ```bash
-export GW_NAME=e2e-gateway
+export GW_NAME=my-gateway
 
 curl -sk -X POST https://localhost:9243/api/v0.9/gateways \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"id\":\"$GW_NAME\",\"displayName\":\"$GW_NAME\",\"endpoints\":[\"http://localhost:8081\"],\"functionalityType\":\"regular\"}" | jq -r .id
+  -d "{\"id\":\"$GW_NAME\",\"displayName\":\"$GW_NAME\",\"endpoints\":[\"http://localhost:8080\"],\"functionalityType\":\"regular\"}" | jq -r .id
 
 export GW_TOKEN=$(curl -sk -X POST https://localhost:9243/api/v0.9/gateways/$GW_NAME/tokens \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}' | jq -r .token)
@@ -101,7 +101,7 @@ Point the controller at the control plane by adding these to `api-platform.env`,
 
 ```bash
 cat >> api-platform.env <<EOF
-APIP_GW_CONTROLLER_CONTROLPLANE_HOST=https://host.docker.internal:9243
+APIP_GW_CONTROLLER_CONTROLPLANE_HOST=host.docker.internal:9243
 APIP_GW_CONTROLLER_CONTROLPLANE_TOKEN=$GW_TOKEN
 APIP_GW_CONTROLLER_CONTROLPLANE_GATEWAY_NAME=$GW_NAME
 APIP_GW_CONTROLLER_CONTROLPLANE_INSECURE_SKIP_VERIFY=true
@@ -111,7 +111,7 @@ docker compose up -d
 curl -fs http://localhost:9094/api/admin/v1/health && echo " gateway ok"
 ```
 
-`GATEWAY_NAME` must match the id you registered, and `INSECURE_SKIP_VERIFY` is needed here only because `setup.sh` generated a self-signed certificate.
+`APIP_GW_CONTROLLER_CONTROLPLANE_GATEWAY_NAME` must match the id you registered, and `INSECURE_SKIP_VERIFY` is needed here only because `setup.sh` generated a self-signed certificate. `CONTROLPLANE_HOST` is a `host:port` with no scheme—the controller prepends `https://` and `wss://` itself, so adding `https://` here makes the connection fail with a `lookup https: no such host` error.
 
 !!! note
     `host.docker.internal` lets the gateway containers reach the Platform API published on your host. On Linux without that alias, put both stacks on one Docker network and use the service name instead.
@@ -125,8 +125,12 @@ This is the seam. Two things have to be true before a portal-issued credential c
 ```bash
 curl -sk -X PUT https://localhost:9543/api-portal/api/v0.9/organizations/default \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d '{"id":"default","displayName":"Default","cpRefId":"default"}'
+  -d '{"id":"default","displayName":"Default","idpRefId":"default","cpRefId":"default"}'
 ```
+
+The update requires `id`, `displayName`, and `idpRefId`. The `id` and `idpRefId` are fixed at seed time and can't change, so pass their existing values (both `default` here)—only `cpRefId` is new.
+
+You can set the same field from the portal UI instead: **Settings > Organization**, under the **ORGANIZATION** group, in the **Control plane reference ID** field. See [Organization settings](../admin-settings/organization-settings.md).
 
 **Second, register the Platform API as a webhook subscriber.** The `secret` here does double duty: it signs each delivery and derives the key that encrypts the credential fields. It must equal `APIP_CP_WEBHOOK_SECRET` on the Platform API, or signature verification and decryption both fail.
 
@@ -136,31 +140,52 @@ export WEBHOOK_SECRET=$(openssl rand -hex 32)
 curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/webhook-subscribers \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d "{\"id\":\"platform-api\",\"displayName\":\"Platform API\",
-       \"targetUrl\":\"https://platform-api:9243/api/portal/v0.9/webhooks/events\",
+       \"targetUrl\":\"https://platform-api:9243/api/internal/v0.9/webhook/events\",
        \"secret\":\"$WEBHOOK_SECRET\",
        \"events\":[\"apikey.*\",\"subscription.*\"],\"enabled\":true}"
 ```
 
-Set the same value as `APIP_CP_WEBHOOK_SECRET` in the portal distribution's `api-platform.env` and restart the Platform API so it picks it up:
+The Platform API's webhook receiver ships disabled, and the shipped `configs/config.toml` has no `[platform_api.webhook]` section wiring in a secret—setting `APIP_CP_WEBHOOK_SECRET` alone does nothing. Enable the receiver and point it at the same secret, then set the value in `api-platform.env` and restart the Platform API so both changes take effect:
 
 ```bash
-cd ../wso2apip-api-portal-1.0.0
+cd ../wso2apip-api-portal-1.0.0-rc3
+
+cat >> configs/config.toml <<'EOF'
+
+[platform_api.webhook]
+enabled = true
+secret  = '{{ env "APIP_CP_WEBHOOK_SECRET" }}'
+EOF
+
 echo "APIP_CP_WEBHOOK_SECRET=$WEBHOOK_SECRET" >> api-platform.env
 chmod 600 api-platform.env
 docker compose up -d platform-api
 ```
+
+!!! important "Without this, every delivery fails with a plain 404"
+    The route isn't conditionally rejecting the request—it's never registered on the server at all while `enabled` is `false`, so any delivery attempt gets a bare 404 with no error detail to explain why.
 
 !!! warning
     `api-platform.env` now holds a live shared secret, alongside the admin password hash. Keep it readable only by its owner, and never commit it to source control.
 
 `targetUrl` uses the container name because the portal reaches the Platform API across the Docker network, not through your host's published port.
 
+!!! note "Webhook deliveries fail with a TLS error"
+    The portal and the Platform API share a self-signed certificate, mounted into the `api-portal` container at `/etc/api-portal/tls/cert.pem`. Node doesn't trust it by default, so a delivery to `https://platform-api:9243/...` fails certificate verification until the portal process is told to trust that certificate. Point `NODE_EXTRA_CA_CERTS` at it and restart the portal:
+
+    ```bash
+    echo "NODE_EXTRA_CA_CERTS=/etc/api-portal/tls/cert.pem" >> api-platform.env
+    docker compose up -d api-portal
+    ```
+
+You can register the same subscriber from the portal UI instead: **Settings > Webhooks**, under **INTEGRATIONS**, with **+ Add webhook**. See [Webhook Integration](../admin-settings/webhook-integration.md).
+
 ## Step 4: Create the secured API
 
 Create a subscription plan on the Platform API:
 
 ```bash
-export PLAN=e2e-gold
+export PLAN=gold
 
 curl -sk -X POST https://localhost:9243/api/v0.9/subscription-plans \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
@@ -176,7 +201,7 @@ Now the API. Two policies do the enforcing: `api-key-auth` reads the key from a 
 ```bash
 export API_ID=$(curl -sk -X POST https://localhost:9243/api/v0.9/rest-apis \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"displayName\":\"Reading List API\",\"context\":\"/reading-list\",\"version\":\"v1\",
+  -d "{\"displayName\":\"Reading List API\",\"context\":\"/reading-list/\$version\",\"version\":\"v1\",
        \"projectId\":\"$PROJECT_ID\",\"lifeCycleStatus\":\"PUBLISHED\",
        \"subscriptionPlans\":[\"$PLAN\"],
        \"upstream\":{\"main\":{\"url\":\"https://apis.bijira.dev/samples/reading-list-api-service/v1.0\"}},
@@ -190,14 +215,14 @@ export API_ID=$(curl -sk -X POST https://localhost:9243/api/v0.9/rest-apis \
 
 The header names are the gateway's, set here—`API-Key` and `Subscription-Key` are the policy defaults, and changing these params changes what consumers must send.
 
-Deploy it to the gateway, then confirm the route is live and enforcing:
+Deploy it to the gateway, then confirm the route is live and enforcing. The deployment takes a `name` label, a `base` source (`current` deploys the latest working copy), and the target `gatewayId`:
 
 ```bash
 curl -sk -X POST https://localhost:9243/api/v0.9/rest-apis/$API_ID/deployments \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"gatewayId\":\"$GW_NAME\"}"
+  -d "{\"name\":\"v1.0\",\"base\":\"current\",\"gatewayId\":\"$GW_NAME\"}"
 
-curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8081/reading-list/v1/books
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/reading-list/v1/books
 ```
 
 Expect **401** or **403**. A **404** means the route isn't programmed yet—wait a few seconds and retry.
@@ -220,12 +245,155 @@ Sync the plan:
 ```bash
 curl -sk -X PUT https://localhost:9543/api-portal/api/v0.9/subscription-plans \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-  -d "[{\"id\":\"$PLAN\",\"displayName\":\"$PLAN\",\"refId\":\"$PLAN\",
+  -d "{\"id\":\"$PLAN\",\"displayName\":\"$PLAN\",\"refId\":\"$PLAN\",
         \"limits\":[{\"limitType\":\"REQUEST_COUNT\",\"limitCount\":10000,
-                     \"timeUnit\":\"HOUR\",\"timeAmount\":1}]}]"
+                     \"timeUnit\":\"HOUR\",\"timeAmount\":1}]}"
 ```
 
-Then publish the API to the portal with `referenceId` set to the Platform API handle, and its specification attached. Write `api.yaml` and `definition.yaml` as shown in [Getting Started](../getting-started.md#step-6-publish-your-first-api), setting `referenceId` to the value of `$API_ID` and listing `$PLAN` under `subscriptionPlans`, then:
+You can set the same `refId` from the portal UI instead: **Settings > Subscription Plans**, under **ORGANIZATION**, in the **External reference ID** field when adding or editing the plan. See [Subscription plans](../admin-settings/subscription-plans.md).
+
+Then publish the API to the portal with `referenceId` set to the Platform API handle, and its specification attached. Adding an API is also possible from **Settings > APIs**, under **CONTENT**, with **+ Add API**—see [Manage APIs](../admin-settings/manage-apis.md)—but that wizard has no field for `referenceId`, so this particular linkage still needs the manifest and the Management API. Create the manifest, setting `referenceId` to the value of `$API_ID` and listing `$PLAN` under `subscriptionPlans`:
+
+```bash
+cat > api.yaml <<EOF
+apiVersion: api-portal.api-platform.wso2.com/v1
+kind: RestApi
+
+metadata:
+  name: reading-list-api-v1
+
+spec:
+  type: REST
+  displayName: Reading List API
+  version: v1
+  description: Track a personal reading list. Every call requires an API key and a subscription token.
+  status: PUBLISHED
+  referenceId: $API_ID
+
+  tags:
+    - reading-list
+
+  labels:
+    - default
+
+  subscriptionPlans:
+    - $PLAN
+
+  agentVisibility: VISIBLE
+
+  businessInformation:
+    businessOwner: Platform Owner
+    businessOwnerEmail: support@example.com
+    technicalOwner: API Team
+    technicalOwnerEmail: architecture@example.com
+
+  endpoints:
+    sandboxUrl: http://localhost:8080/reading-list/v1
+    productionUrl: http://localhost:8080/reading-list/v1
+EOF
+```
+
+Create the matching OpenAPI definition:
+
+```bash
+cat > definition.yaml <<'EOF'
+openapi: 3.0.1
+info:
+  title: Reading List API
+  version: v1
+  description: |
+    Track a personal reading list — add books, update their reading status, and
+    remove them when you're done. Requires an API key and a subscription token.
+servers:
+  - url: http://localhost:8080/reading-list/v1
+security:
+  - ApiKeyHeader: []
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: API-Key
+  parameters:
+    SubscriptionKeyHeader:
+      name: Subscription-Key
+      x-header-type: subscription-key
+      in: header
+      required: true
+      schema:
+        type: string
+  schemas:
+    Book:
+      type: object
+      required: [title, author, status]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        title:
+          type: string
+          example: The Great Gatsby
+        author:
+          type: string
+          example: F. Scott Fitzgerald
+        status:
+          type: string
+          enum: [to_read, reading, read]
+paths:
+  /books:
+    parameters:
+      - $ref: '#/components/parameters/SubscriptionKeyHeader'
+    get:
+      summary: List books
+      responses:
+        '200':
+          description: OK. The reading list.
+    post:
+      summary: Add a book
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Book'
+      responses:
+        '201':
+          description: Created. The newly added book.
+  /books/{id}:
+    parameters:
+      - $ref: '#/components/parameters/SubscriptionKeyHeader'
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get a book
+      responses:
+        '200':
+          description: OK. The requested book.
+    put:
+      summary: Update a book
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Book'
+      responses:
+        '200':
+          description: OK. The updated book.
+    delete:
+      summary: Remove a book
+      responses:
+        '204':
+          description: No Content. The book was removed.
+EOF
+```
+
+Publish both files:
 
 ```bash
 curl -sk -X POST https://localhost:9543/api-portal/api/v0.9/apis \
@@ -253,7 +421,7 @@ Send both credentials, in the headers the policies named:
 export API_KEY='<the key from the portal>'
 export SUB_TOKEN='<the subscription token from the portal>'
 
-curl -i http://localhost:8081/reading-list/v1/books \
+curl -i http://localhost:8080/reading-list/v1/books \
   -H "API-Key: $API_KEY" \
   -H "Subscription-Key: $SUB_TOKEN"
 ```
@@ -267,9 +435,9 @@ Propagation takes a moment. If you get a 401 or 403 immediately after generating
 Drop one header at a time—each should be rejected:
 
 ```bash
-curl -s -o /dev/null -w 'no credentials:      %{http_code}\n' http://localhost:8081/reading-list/v1/books
-curl -s -o /dev/null -w 'key only:            %{http_code}\n' http://localhost:8081/reading-list/v1/books -H "API-Key: $API_KEY"
-curl -s -o /dev/null -w 'subscription only:   %{http_code}\n' http://localhost:8081/reading-list/v1/books -H "Subscription-Key: $SUB_TOKEN"
+curl -s -o /dev/null -w 'no credentials:      %{http_code}\n' http://localhost:8080/reading-list/v1/books
+curl -s -o /dev/null -w 'key only:            %{http_code}\n' http://localhost:8080/reading-list/v1/books -H "API-Key: $API_KEY"
+curl -s -o /dev/null -w 'subscription only:   %{http_code}\n' http://localhost:8080/reading-list/v1/books -H "Subscription-Key: $SUB_TOKEN"
 ```
 
 ## Step 8: Watch a lifecycle change propagate
@@ -277,7 +445,7 @@ curl -s -o /dev/null -w 'subscription only:   %{http_code}\n' http://localhost:8
 Credential changes travel the same path. In the portal, revoke the API key, then call again with it:
 
 ```bash
-curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8081/reading-list/v1/books \
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/reading-list/v1/books \
   -H "API-Key: $API_KEY" -H "Subscription-Key: $SUB_TOKEN"
 ```
 
@@ -293,6 +461,7 @@ The same holds for the subscription side, where a rejection reads as **403** rat
 | `503` when generating an API key | No gateway is connected for that API—deploy it first |
 | Credentials never start working | The webhook secret differs between the portal subscriber and `APIP_CP_WEBHOOK_SECRET`, so signatures fail and credential fields can't be decrypted |
 | Only the subscription fails (`403`) | The portal plan's `refId` doesn't match the Platform API plan handle, or two plans share a display name |
+| Every delivery gets a `404` | The Platform API's webhook receiver isn't enabled—add `[platform_api.webhook]` with `enabled = true` to `configs/config.toml` and restart it |
 | Nothing arrives at all | The organization's `cpRefId` doesn't match the Platform API organization handle |
 | Deliveries fail once and stop | Webhook delivery is attempted exactly once with no retry—check delivery history, see [Webhook Events](../rest-api/webhook-events.md) |
 


### PR DESCRIPTION
## Purpose
$subject

## Checklist
 - [x] Verified that `llms.txt` (located at `en/docs/llms.txt`) is updated for AI readiness content. 
 - [x] Ensured meaningful alt text for images and that the information contained in an image also appears in text so the relevant info exists in the body of the document.
 - [x] Added or updated frontmatter for the respective pages.

## Approach
Corrected the gateway's port
Added the missing api definition and api metadata related steps